### PR TITLE
split patches w/ no "deleted" patch

### DIFF
--- a/lib/updatePatches.js
+++ b/lib/updatePatches.js
@@ -6,9 +6,49 @@ const util = require('../lib/util')
 const updatePatches = (options) => {
   config.update(options)
 
-  const diffArgs = ['diff', '--full-index', '--ignore-space-at-eol']
-  let diff = util.run('git', diffArgs, { cwd: config.projects.chrome.dir })
-  fs.writeFileSync(path.join(config.projects.antimuon.dir, 'patches', 'master_patch.patch'), diff.stdout)
+  const runOptions = { cwd: config.projects.chrome.dir }
+  const patchDir = path.join(config.projects.antimuon.dir, 'patches')
+
+  console.log('updatePatches writing files to: ' + patchDir)
+
+  // grab Modified (and later Deleted) files but not Created (since we copy those)
+  const modifiedDiffArgs = ['diff', '--diff-filter=M', '--name-only', '--ignore-space-at-eol']
+  let modifiedDiff = util.run('git', modifiedDiffArgs, runOptions)
+  let moddedFileList = modifiedDiff.stdout.toString().split('\n').filter(s => s.length > 0)
+
+  let n = moddedFileList.length
+
+  // When splitting one large diff into a per-file diff, there are a few ways
+  // you can go about it. Because different files can have the same name
+  // (by being located in different directories), you need to avoid collisions.
+  // Mirroring the directory structure seems undesirable.
+  // Prefixing with numbers works but is O(n) volatile for O(1) additions
+  // We choose here to flatten the directory structure by replacing separators
+  // In practice this will avoid collisions. Should a pathological case ever
+  // appear, you can quickly patch this by changing the separator, even
+  // to something longer
+
+  const desiredReplacementSeparator = '-'
+  const patchExtension = '.patch'
+
+  for (var i = 0; i < n; i++) {
+    const old = moddedFileList[i]
+    let revised = old
+
+    //replacing forward slashes
+    //since git on Windows doesn't use backslashes, this is sufficient
+    revised = revised.replace(/\//g, desiredReplacementSeparator)
+
+    const singleDiffArgs = ['diff', '--src-prefix=a/', '--dst-prefix=b/', '--full-index', old]
+    let singleDiff = util.run('git', singleDiffArgs, runOptions)
+
+    const contents = singleDiff.stdout.toString()
+    const filename = revised + patchExtension
+
+    fs.writeFileSync(path.join(patchDir, filename), contents)
+
+    console.log('updatePatches wrote ' + (1 + i) + '/' + n + ': ' + filename)
+  }
 }
 
 module.exports = updatePatches


### PR DESCRIPTION
and one big file for Deleted files
for issue brave/brave#36

fixes from pr comments:
use '-' as separator
only need to replace '/' not '\\'

standardize diff prefixes to a/ and b/

don't create master deleted patch