### PR TITLE
updateBranding for create_distr

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       },
       "antimuon": {
         "dir": "src/brave",
-        "branch": "linux_installer_packages",
+        "branch": "master",
         "repository": {
           "url": "git@github.com:brave/antimuon.git"
         }


### PR DESCRIPTION
Update branding is required to succeed with creation of the package right after the sources checkout.