### PR TITLE
override cc files during compilation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -79,7 +79,7 @@ Config.prototype.buildArgs = function () {
   if (sccache) {
     args.cc_wrapper = sccache
   }
-
+  args.cc_wrapper='../../brave/script/redirect-cc.py';
   return args
 }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       },
       "antimuon": {
         "dir": "src/brave",
-        "branch": "master",
+        "branch": "override_cc",
         "repository": {
           "url": "git@github.com:brave/antimuon.git"
         }


### PR DESCRIPTION
This is one of PRs for https://github.com/brave/brave/issues/60 .
Related Antimuon PR is https://github.com/brave/antimuon/pull/33 .

It defines cc_wrapper as a script which redirects compiler to use file from brave/chromium_src if available. 
Antimuon branch is changed to `override_cc`. It will be required to switch it back to master after merge.
