### PR TITLE
symbol_level is set to 1 for x86 Linux

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -75,6 +75,11 @@ Config.prototype.buildArgs = function () {
     args.is_win_fastlink = true
   }
 
+  if (this.targetArch === 'x86' && process.platform === 'linux') {
+    // Minimal symbols for target Linux x86, because ELF32 cannot be > 4GiB
+    args.symbol_level = 1
+  }
+
   // TODO: Build redirect-cc.cmd in such a way that it still works with ccache if configured
   /*
   let sccache = getNPMConfig(['sccache'])


### PR DESCRIPTION
With default `symbol_level=2` x86 brave binary reached 6.4 GiB, this is beyond ELF32 can handle and the next steps had failed.