### PR TITLE
Linux packages renamed

### DIFF
--- a/lib/createDist.js
+++ b/lib/createDist.js
@@ -29,10 +29,10 @@ const renameLinuxDistr = (options) => {
     fs.readdir(config.outputDir, function(err, items) {
       for (var i=0; i<items.length; i++) {
         var newFileName = '';
-        if ((new RegExp(/^brave-browser-stable.*rpm$/)).test(items[i])) {
+        if ((new RegExp(/^brave-browser-[0-9.-]+.*rpm$/)).test(items[i])) {
           newFileName = (options.target_arch === 'x86') ?
             I386_RPM_NAME : AMD64_RPM_NAME;
-        } else if ((new RegExp(/^brave-browser-stable.*deb$/)).test(items[i])) {
+        } else if ((new RegExp(/^brave-browser_[0-9.-]+.*deb$/)).test(items[i])) {
           newFileName = (options.target_arch === 'x86') ?
             I386_DEB_NAME : AMD64_DEB_NAME;
         } else if ((new RegExp(/^brave-browser-(unstable|beta).*(rpm|deb)$/)).test(items[i])) {


### PR DESCRIPTION
Rename Linux packages. This is done without touching of chromium gn files.

Fix https://github.com/brave/brave/issues/72