### PR TITLE
Use default config so ninja is in PATH

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -12,13 +12,8 @@ const test = (suite, options) => {
     '--v=' + options.v,
   ]
 
-  let cmdOptions = {
-    stdio: 'inherit',
-    shell: true
-  }
-
   // Build the tests
-  util.run('ninja', ['-C', config.outputDir, suite], cmdOptions)
+  util.run('ninja', ['-C', config.outputDir, suite], config.defaultOptions)
 
   let testBinary;
   if (process.platform === 'win32') {
@@ -28,7 +23,7 @@ const test = (suite, options) => {
   }
 
   // Run the tests
-  util.run(path.join(config.outputDir, testBinary), braveArgs, cmdOptions)
+  util.run(path.join(config.outputDir, testBinary), braveArgs, config.defaultOptions)
 }
 
 module.exports = test


### PR DESCRIPTION
config.defaultOptions contains an env which doesn't require `ninja` to be in your path. It already also includes both of these properties:
```
{
   stdio: 'inherit',
   shell: true
}
```

Without this PR, you'd need to have `PATH="$PATH:/path/to/brave/vendor/depot_tools"`.