### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!--
+Have you searched for similar issues? We have received a lot of feedback and bug reports that we have closed as duplicates. Before submitting this issue, please visit our community site for common ones: https://community.brave.com/c/common-issues
+-->
+
+### Description
+<!--
+[Description of the issue]
+-->
+
+
+### Steps to Reproduce
+<!--
+Please add a series of steps to reproduce the problem. See https://stackoverflow.com/help/mcve for in depth information on how to create a minimal, complete, and verifiable example.
+-->
+
+  1.
+  2.
+  3.
+
+
+**Actual result:**
+<!--
+Please add screenshots if needed.
+-->
+
+
+**Expected result:**
+
+
+**Reproduces how often:**
+<!--
+What percentage of the time does it reproduce?
+-->
+
+
+### Brave Version
+
+**about:brave info:**
+<!--
+Please open about:brave, copy the version information, and paste it.
+-->
+
+
+**Reproducible on current live release:**
+<!--
+Is this a problem with the live build? It matters for triage reasons.
+-->
+
+
+### Additional Information
+<!--
+Any additional information, related issues, extra QA steps, configuration or data that might be necessary to reproduce the issue.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Submitter Checklist:
+
+- [ ] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
+- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
+- [ ] Added/updated tests for this change (for new code or code which already has tests).
+- [ ] Ran `git rebase -i` to squash commits (if needed).
+- [ ] Tagged reviewers and labelled the pull request as needed.
+- [ ] Request a security/privacy review as needed.
+
+## Test Plan:
+
+
+## Reviewer Checklist:
+
+- [ ] New files have MPL-2.0 license header.
+- [ ] Request a security/privacy review as needed.
+- [ ] Adequate test coverage exists to prevent regressions


### PR DESCRIPTION
These templates will be pre-filled into issues and pull requests
respectively on GitHub.

This is mostly just copied from brave/browser-laptop with some slight modifications.