### PR TITLE
Add channel option to build command

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -35,6 +35,7 @@ const Config = function () {
   const braveCoreDirPackage = path.join(this.projects['brave-core'].dir, 'package')
   this.braveCoreVersion = getNPMConfig(['brave_version']) || (fs.existsSync(braveCoreDirPackage + '.json') && require(braveCoreDirPackage)['version']) || ''
   this.releaseTag = this.braveCoreVersion.split('+')[0]
+  this.channel = ''
 }
 
 Config.prototype.buildArgs = function () {
@@ -53,6 +54,7 @@ Config.prototype.buildArgs = function () {
     is_official_build: this.officialBuild,
     is_debug: this.buildConfig !== 'Release',
     dcheck_always_on: this.buildConfig !== 'Release',
+    brave_channel: this.channel,
      brave_google_api_key: this.googleApiKey,
      brave_google_api_endpoint: this.googleApiEndpoint,
      brave_product_name: getNPMConfig(['brave_product_name']) || "brave-core",
@@ -194,6 +196,10 @@ Config.prototype.update = function (options) {
   } else {
     this.officialBuild = this.buildConfig === 'Release'
   }
+
+  // In chromium src, empty string represents stable channel.
+  if (options.channel !== 'release')
+    this.channel = options.channel
 
   this.projectNames.forEach((projectName) => {
     // don't update refs for projects that have them

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -29,6 +29,7 @@ program
   .option('--brave_google_api_key <brave_google_api_key>')
   .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
   .option('--no_branding_update', 'don\'t copy BRANDING to the chrome theme dir')
+  .option('--channel <target_chanel>', 'target channel to build', /^(beta|canary|dev|release)$/i, 'release')
   .arguments('[build_config]')
   .action(build)
 


### PR DESCRIPTION
To build with specific channel, pass channel option to build.
Options can be beta, canary, dev and release.
Issue: https://github.com/brave/brave-browser/issues/10
Depends on https://github.com/brave/brave-core/pull/78

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
