### PR TITLE
Add CLI arg for starting without Brave extension

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -13,6 +13,9 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   if (options.no_sandbox) {
     braveArgs.push('--no-sandbox')
   }
+  if (options.disable_brave_extension) {
+    braveArgs.push('--disable-brave-extension')
+  }
 
   let cmdOptions = {
     stdio: 'inherit',

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -51,6 +51,7 @@ program
   .option('--v [log_level]', 'set log level to [log_level]', parseInt, '0')
   .option('--user_data_dir_name [base_name]', 'set user data directory base name to [base_name]', 'brave-development')
   .option('--no_sandbox', 'disable the sandbox')
+  .option('--disable_brave_extension', 'disable loading the Brave extension')
   .arguments('[build_config]')
   .action(start)
 


### PR DESCRIPTION
Fix #150
Related: https://github.com/brave/brave-core/pull/87
Documented here: https://github.com/brave/brave-browser/wiki/Debugging-brave-extension

You can do this with:

```
npm run start -- --disable_brave_extension
```

or

```
yarn start --disable_brave_extension
```

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
