### PR TITLE
Update scripts for create_dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src
 npm-debug.log
 .gclient
 .sccache
+**.sw[po]

--- a/lib/build.js
+++ b/lib/build.js
@@ -9,7 +9,7 @@ const build = (buildConfig = config.defaultBuildConfig, options) => {
     util.updateBranding()
   }
 
-  util.buildMuon()
+  util.buildMuon('brave')
 }
 
 module.exports = build

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,7 @@ const Config = function () {
   this.resourcesDir = path.join(this.rootDir, 'resources')
   this.defaultGClientFile = path.join(this.rootDir, '.gclient')
   this.gClientFile = process.env.BRAVE_GCLIENT_FILE || this.defaultGClientFile
+  this.gClientVerbose = getNPMConfig(['gclient_verbose']) || false
   this.targetArch = 'x64'
   this.gypTargetArch = 'x64'
   this.officialBuild = true
@@ -35,6 +36,8 @@ const Config = function () {
   const braveCoreDirPackage = path.join(this.projects['brave-core'].dir, 'package')
   this.braveCoreVersion = getNPMConfig(['brave_version']) || (fs.existsSync(braveCoreDirPackage + '.json') && require(braveCoreDirPackage)['version']) || ''
   this.releaseTag = this.braveCoreVersion.split('+')[0]
+  this.mac_signing_identifier = getNPMConfig(['mac_signing_identifier']) || ''
+  this.mac_signing_keychain = getNPMConfig(['mac_signing_keychain']) || 'login'
   this.channel = ''
 }
 
@@ -66,7 +69,8 @@ Config.prototype.buildArgs = function () {
   }
 
   if (process.platform === 'darwin') {
-    args.mac_signing_identifier = getNPMConfig(['mac_signing_identifier']) || ''
+    args.mac_signing_identifier = this.mac_signing_identifier
+    args.mac_signing_keychain = this.mac_signing_keychain
   }
 
   if (this.debugBuild) {
@@ -223,6 +227,15 @@ Config.prototype.update = function (options) {
   if (options.channel !== 'release')
     this.channel = options.channel
 
+  if (options.mac_signing_identifier)
+    this.mac_signing_identifier = options.mac_signing_identifier
+
+  if (options.mac_signing_keychain)
+    this.mac_signing_keychain = options.mac_signing_keychain
+
+  if (options.gclient_verbose)
+    this.gClientVerbose = options.gclient_verbose
+
   this.projectNames.forEach((projectName) => {
     // don't update refs for projects that have them
     if (!this.projects[projectName].ref)
@@ -262,6 +275,7 @@ Object.defineProperty(Config.prototype, 'defaultOptions', {
       stdio: 'inherit',
       cwd: this.srcDir,
       shell: true,
+      git_cwd: '.',
     }
   },
 })

--- a/lib/createDist.js
+++ b/lib/createDist.js
@@ -3,19 +3,16 @@ const util = require('../lib/util')
 const path = require('path')
 const fs = require('fs-extra')
 
-const createDist = (options) => {
+const createDist = (buildConfig = config.defaultBuildConfig, options) => {
+  config.buildConfig = buildConfig
   config.update(options)
-
-  let cmdOptions = config.defaultOptions
-  const args = util.buildArgsToString(config.buildArgs())
 
   if (!options.no_branding_update) {
     util.updateBranding()
   }
 
   fs.removeSync(path.join(config.outputDir, 'dist'))
-  util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], cmdOptions)
-  util.run('ninja', ['-C', config.outputDir, 'create_dist'], cmdOptions)
+  util.buildMuon('create_dist')
 
   renameLinuxDistr(options)
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,7 @@ const config = require('./config')
 const fs = require('fs-extra')
 
 const runGClient = (args, options = {}) => {
+  if (options.verbose) args.push('--verbose')
   options.cwd = options.cwd || config.rootDir
   options = mergeWithDefault(options)
   options.env.GCLIENT_FILE = config.gClientFile
@@ -16,9 +17,11 @@ const mergeWithDefault = (options) => {
 
 const util = {
   run: (cmd, args = [], options = {}) => {
+    if (!options.env) options.env = {}
     console.log(cmd, args.join(' '))
     const continueOnFail = options.continueOnFail
     delete options.continueOnFail
+
 
     const prog = spawnSync(cmd, args, options)
     if (prog.status !== 0) {
@@ -70,20 +73,21 @@ const util = {
     fs.copySync(path.join(braveAppDir, 'strings'), path.join(chromeComponentsDir, 'strings'))
   },
 
-  buildMuon: (options = config.defaultOptions) => {
-    console.log('building brave...')
+  buildMuon: (target = 'brave', options = config.defaultOptions) => {
+    console.log('building ' + target + '...')
 
     const args = util.buildArgsToString(config.buildArgs())
     util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], options)
-    util.run('ninja', ['-C', config.outputDir, 'brave'], options)
+    util.run('ninja', ['-C', config.outputDir, target], options)
   },
 
-  submoduleSync: (options = { cwd: config.rootDir }) => {
+  submoduleSync: (options = {}) => {
+    if (!options.cwd) options.cwd = config.rootDir // default cwd `./src` may not exist yet
     options = mergeWithDefault(options)
     util.run('git', ['submodule', 'sync'], options)
     util.run('git', ['submodule', 'update', '--init', '--recursive'], options)
-    util.run('git', ['clean', '-fxd'], Object.assign(options, {cwd: config.depotToolsDir}))
-    util.run('git', ['reset', '--hard', 'HEAD'], Object.assign(options, {cwd: config.depotToolsDir}))
+    util.run('git', ['-C', config.depotToolsDir, 'clean', '-fxd'], options)
+    util.run('git', ['-C', config.depotToolsDir, 'reset', '--hard', 'HEAD'], options)
   },
 
   gclientSync: (options = {}) => {
@@ -95,17 +99,19 @@ const util = {
   },
 
   fetch: (options = {}) => {
+    if (!options.cwd) options.cwd = config.rootDir
     options = mergeWithDefault(options)
-    util.run('git', ['fetch', '--all', '--tags'], options)
+    util.run('git', ['-C', options.git_cwd, 'fetch', '--all', '--tags'], options)
   },
 
   setVersion: (version, options = {}) => {
-    util.run('git', ['clean', '-f'], options)
-    util.run('git', ['reset', '--hard', version], options)
+    if (!options.cwd) options.cwd = config.rootDir
+    util.run('git', ['-C', options.git_cwd, 'clean', '-f'], options)
+    util.run('git', ['-C', options.git_cwd, 'reset', '--hard', version], options)
   },
 
   setDepVersion: (dir, version) => {
-    const options = { cwd: dir }
+    const options = { git_cwd: dir }
     util.fetch(options)
     util.setVersion(version, options)
   },

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -24,6 +24,8 @@ program
   .command('build')
   .option('-C <build_dir>', 'build config (out/Debug, out/Release')
   .option('--target_arch <target_arch>', 'target architecture', 'x64')
+  .option('--mac_signing_identifier <id>', 'The identifier to use for signing')
+  .option('--mac_signing_keychain <keychain>', 'The identifier to use for signing', 'login')
   .option('--debug_build <debug_build>', 'keep debugging symbols')
   .option('--official_build <official_build>', 'force official build settings')
   .option('--brave_google_api_key <brave_google_api_key>')
@@ -35,12 +37,17 @@ program
 
 program
   .command('create_dist')
-  .option('--mac_signing_identifier', 'The identifier to use for signing')
+  .option('-C <build_dir>', 'build config (out/Debug, out/Release')
   .option('--target_arch <target_arch>', 'target architecture', 'x64')
+  .option('--mac_signing_identifier <id>', 'The identifier to use for signing')
+  .option('--mac_signing_keychain <keychain>', 'The identifier to use for signing', 'login')
   .option('--debug_build <debug_build>', 'keep debugging symbols')
   .option('--official_build <official_build>', 'force official build settings')
+  .option('--brave_google_api_key <brave_google_api_key>')
+  .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
   .option('--no_branding_update', 'don\'t copy BRANDING to the chrome theme dir')
   .option('--channel <target_chanel>', 'target channel to build', /^(beta|canary|dev|release)$/i, 'release')
+  .arguments('[build_config]')
   .action(createDist)
 
 program

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -9,12 +9,14 @@ const projectNames = config.projectNames.filter((project) => config.projects[pro
 program
   .version(process.env.npm_package_version)
   .option('--gclient_file <file>', 'gclient config file location')
+  .option('--gclient_verbose', 'verbose output for gclient')
   .option('--run_hooks', 'run gclient hooks')
   .option('--run_sync', 'run gclient sync')
   .option('--submodule_sync', 'run submodule sync')
   .option('--init', 'initialize all dependencies')
   .option('--all', 'update all projects')
 projectNames.forEach((project) => {
+  project = project.replace('-', '_')
   program.option('--' + project + '_ref <ref>', project + ' ref to checkout')
 })
 
@@ -22,30 +24,30 @@ program.parse(process.argv)
 config.update(program)
 
 if (program.init || program.submodule_sync) {
-  util.submoduleSync()
+  util.submoduleSync({verbose: config.gClientVerbose})
 }
 
 if (program.init) {
-  util.buildGClientConfig()
+  util.buildGClientConfig({verbose: config.gClientVerbose})
 }
 
 if (program.init) {
-  util.gclientSync()
+  util.gclientSync({verbose: config.gClientVerbose})
 }
 
 let updatedVersion = false
 
 projectNames.forEach((project) => {
-  if (program.init || program.all || program[project + '_ref']) {
+  if (program.init || program.all || program[project.replace('-', '_') + '_ref']) {
     updatedVersion = true
     util.setDepVersion(config.projects[project].dir, config.projects[project].ref)
   }
 })
 
 if (updatedVersion || program.init || program.run_sync) {
-  util.gclientSync()
+  util.gclientSync({verbose: config.gClientVerbose})
 }
 
 if (updatedVersion || program.init || program.run_hooks) {
-  util.gclientRunhooks()
+  util.gclientRunhooks({verbose: config.gClientVerbose})
 }

--- a/src/.gitkeep
+++ b/src/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep


### PR DESCRIPTION
These are various improvements/fixes I added while working on the CI builds.

    * Add mac signing id and keychain parameters
    * Add gclient_verbose option to sync
    * Allow util.js func options to be set with out explicit cwd
    * Use git -C option to specify repos
    
      Switching directories on windows can cause strange issues in
      the case of depot_tools assumingly because the shell will see
      the git in the current directory and run that instead of what is
      run elsewhere.
    
    * Fix setting references on the command line with yarn sync.
    
      Commander camelcases options with dashs which breaks when used with
      '--brave-core_ref'. This also renames the option to --brave_core_ref

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Have been using in the new CI infrastructure.

Will likely need to come back and start adding some tests for ./lib/* (none currently).

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
