### PR TITLE
Add the ability to filter tests via npm

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -12,6 +12,10 @@ const test = (suite, options) => {
     '--v=' + options.v,
   ]
 
+  if (options.filter) {
+    braveArgs.push('--gtest_filter=' + options.filter)
+  }
+
   // Build the tests
   util.run('ninja', ['-C', config.outputDir, suite], config.defaultOptions)
 

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -79,6 +79,7 @@ program
 program
   .command('test <suite>')
   .option('--v [log_level]', 'set log level to [log_level]', parseInt, '0')
+  .option('--filter <filter>', 'set test filter')
   .action(test)
 
 program


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/238

**Example running all tests:**

`npm run test -- brave_browser_tests`

**Example running some specific tests:**

`npm run test -- brave_browser_tests --filter=BraveContentSettingsObserverBrowserTest.*`

I also updated test docs here:
https://github.com/brave/brave-browser/wiki/Tests


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
