### PR TITLE
Enable start/test command in debug mode

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -182,6 +182,11 @@ Config.prototype.update = function (options) {
     this.__outputDir = options.C
   }
 
+  // Start option to run debug build.
+  if (options.Debug) {
+    this.buildConfig = 'Debug'
+  }
+
   if (options.target_arch === 'x86') {
     this.targetArch = options.target_arch
     this.gypTargetArch = 'ia32'

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -82,6 +82,7 @@ program
   .command('test <suite>')
   .option('--v [log_level]', 'set log level to [log_level]', parseInt, '0')
   .option('--filter <filter>', 'set test filter')
+  .option('--Debug', 'build and run tests in debug')
   .action(test)
 
 program

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -54,6 +54,7 @@ program
   .option('--user_data_dir_name [base_name]', 'set user data directory base name to [base_name]', 'brave-development')
   .option('--no_sandbox', 'disable the sandbox')
   .option('--disable_brave_extension', 'disable loading the Brave extension')
+  .option('--Debug', 'run debug build')
   .arguments('[build_config]')
   .action(start)
 


### PR DESCRIPTION
Use `yarn start --Debug` for executing debug build binary built by `yarn build -C out/Debug`.
Use `yarn test --Debug brave_unit_tests` to build and run our test cases in debug mode.

Close: https://github.com/brave/brave-browser/issues/136

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
