### PR TITLE
Allow running tests in Release

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -3,8 +3,8 @@ const path = require('path')
 const config = require('../lib/config')
 const util = require('../lib/util')
 
-const test = (suite, options) => {
-  config.buildConfig = config.defaultBuildConfig
+const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
+  config.buildConfig = buildConfig
   config.update(options)
 
   const braveArgs = [

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -81,6 +81,7 @@ program
   .command('test <suite>')
   .option('--v [log_level]', 'set log level to [log_level]', parseInt, '0')
   .option('--filter <filter>', 'set test filter')
+  .arguments('[build_config]')
   .action(test)
 
 program


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/262

The wiki is also updated.

This adds an extra optional argument to run tests in Release mode

npm run test -- brave_browser_tests Release

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
