### PR TITLE
Cleanup for #229

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -9,7 +9,7 @@ const build = (buildConfig = config.defaultBuildConfig, options) => {
     util.updateBranding()
   }
 
-  util.buildMuon('brave')
+  util.buildTarget()
 }
 
 module.exports = build

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,7 @@ const Config = function () {
   this.buildConfig = this.defaultBuildConfig
   this.projectNames = []
   this.projects = {}
+  this.buildTarget = 'brave'
   this.rootDir = path.join(path.dirname(__filename), '..')
   this.scriptDir = path.join(this.rootDir, 'scripts')
   this.depotToolsDir = path.join(this.rootDir, 'vendor', 'depot_tools')

--- a/lib/config.js
+++ b/lib/config.js
@@ -176,7 +176,8 @@ Config.prototype.buildProjects = function () {
       url: getNPMConfig(['projects', projectName, 'repository', 'url']),
       gclientName: getNPMConfig(['projects', projectName, 'dir']),
       dir: path.join(this.rootDir, getNPMConfig(['projects', projectName, 'dir'])),
-      custom_deps: packages.config.projects[projectName].custom_deps
+      custom_deps: packages.config.projects[projectName].custom_deps,
+      arg_name: projectName.replace('-', '_')
     }
   })
 }
@@ -239,12 +240,13 @@ Config.prototype.update = function (options) {
 
   this.projectNames.forEach((projectName) => {
     // don't update refs for projects that have them
-    if (!this.projects[projectName].ref)
+    let project = this.projects[projectName]
+    if (!project.ref)
       return
 
-    let ref = options[projectName + '_ref']
+    let ref = options[project.arg_name + '_ref']
     if (ref && ref !== 'default' && ref !== '') {
-      this.projects[projectName].ref = ref
+      project.ref = ref
     }
   })
 }

--- a/lib/createDist.js
+++ b/lib/createDist.js
@@ -12,7 +12,8 @@ const createDist = (buildConfig = config.defaultBuildConfig, options) => {
   }
 
   fs.removeSync(path.join(config.outputDir, 'dist'))
-  util.buildMuon('create_dist')
+  config.buildTarget = 'create_dist'
+  util.buildTarget()
 
   renameLinuxDistr(options)
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,7 @@ const config = require('./config')
 const fs = require('fs-extra')
 
 const runGClient = (args, options = {}) => {
-  if (options.verbose) args.push('--verbose')
+  if (config.gClientVerbose) args.push('--verbose')
   options.cwd = options.cwd || config.rootDir
   options = mergeWithDefault(options)
   options.env.GCLIENT_FILE = config.gClientFile
@@ -73,12 +73,12 @@ const util = {
     fs.copySync(path.join(braveAppDir, 'strings'), path.join(chromeComponentsDir, 'strings'))
   },
 
-  buildMuon: (target = 'brave', options = config.defaultOptions) => {
-    console.log('building ' + target + '...')
+  buildTarget: (options = config.defaultOptions) => {
+    console.log('building ' + config.buildTarget + '...')
 
     const args = util.buildArgsToString(config.buildArgs())
     util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], options)
-    util.run('ninja', ['-C', config.outputDir, target], options)
+    util.run('ninja', ['-C', config.outputDir, config.buildTarget], options)
   },
 
   submoduleSync: (options = {}) => {

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -15,9 +15,9 @@ program
   .option('--submodule_sync', 'run submodule sync')
   .option('--init', 'initialize all dependencies')
   .option('--all', 'update all projects')
-projectNames.forEach((project) => {
-  project = project.replace('-', '_')
-  program.option('--' + project + '_ref <ref>', project + ' ref to checkout')
+projectNames.forEach((name) => {
+  let project = config.projects[name]
+  program.option('--' + project.arg_name + '_ref <ref>', name + ' ref to checkout')
 })
 
 program.parse(process.argv)
@@ -37,10 +37,11 @@ if (program.init) {
 
 let updatedVersion = false
 
-projectNames.forEach((project) => {
-  if (program.init || program.all || program[project.replace('-', '_') + '_ref']) {
+projectNames.forEach((name) => {
+  let project = config.projects[name]
+  if (program.init || program.all || program[project.arg_name + '_ref']) {
     updatedVersion = true
-    util.setDepVersion(config.projects[project].dir, config.projects[project].ref)
+    util.setDepVersion(project.dir, project.ref)
   }
 })
 

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -24,15 +24,15 @@ program.parse(process.argv)
 config.update(program)
 
 if (program.init || program.submodule_sync) {
-  util.submoduleSync({verbose: config.gClientVerbose})
+  util.submoduleSync()
 }
 
 if (program.init) {
-  util.buildGClientConfig({verbose: config.gClientVerbose})
+  util.buildGClientConfig()
 }
 
 if (program.init) {
-  util.gclientSync({verbose: config.gClientVerbose})
+  util.gclientSync()
 }
 
 let updatedVersion = false
@@ -45,9 +45,9 @@ projectNames.forEach((project) => {
 })
 
 if (updatedVersion || program.init || program.run_sync) {
-  util.gclientSync({verbose: config.gClientVerbose})
+  util.gclientSync()
 }
 
 if (updatedVersion || program.init || program.run_hooks) {
-  util.gclientRunhooks({verbose: config.gClientVerbose})
+  util.gclientRunhooks()
 }


### PR DESCRIPTION
Few things to clean up post #229 merge

* Fix `yarn run sync --<project>_ref=` command
* Set build target through the config for create_dist
* Check config.gClientVerbose directly and remove unused options
* buildMuon
  * Renamed to buildTarget
  * Now uses build target set in config

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.

## Test Plan:
Just manually right now across various machines (which is likely why so many bugs are getting missed here). Have this ticket open for adding testing to the build tools in general https://github.com/brave/brave-browser/issues/304.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
