### PR TITLE
Copying our pre-generated midl files to overwrite upstream midl files

### DIFF
--- a/lib/updatePatches.js
+++ b/lib/updatePatches.js
@@ -16,7 +16,7 @@ const updatePatches = (options) => {
   let modifiedDiff = util.run('git', modifiedDiffArgs, runOptions)
   let moddedFileList = modifiedDiff.stdout.toString()
     .split('\n')
-    .filter(s => s.length > 0 && !s.endsWith('.xtb') && !s.endsWith('.png'))
+    .filter(s => s.length > 0 && !s.endsWith('.xtb') && !s.endsWith('.png') && !s.includes('google_update_idl'))
 
   let n = moddedFileList.length
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -77,8 +77,22 @@ const util = {
     fs.copySync(path.join(braveAppDir, 'strings'), path.join(chromeComponentsDir, 'strings'))
   },
 
+  // Chromium compares pre-installed midl files and generated midl files from IDL during the build to check integrity.
+  // Generated files during the build time and upstream pre-installed files are different because we use different IDL file.
+  // So, we should copy our pre-installed files to overwrite upstream pre-installed files.
+  // After checking, pre-installed files are copied to gen dir and they are used to compile.
+  // So, this copying in every build doesn't affect compile performance.
+  updateOmahaMidlFiles: () => {
+    console.log('update omaha midl files...')
+    const srcDir = path.join(config.projects['brave-core'].dir, 'win_build_output', 'midl', 'google_update')
+    const dstDir = path.join(config.srcDir, 'third_party', 'win_build_output', 'midl', 'google_update')
+    fs.copySync(srcDir, dstDir)
+  },
+
   buildTarget: (options = config.defaultOptions) => {
     console.log('building ' + config.buildTarget + '...')
+
+    util.updateOmahaMidlFiles()
 
     const args = util.buildArgsToString(config.buildArgs())
     util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], options)


### PR DESCRIPTION
Chromum compares pre-installed midl files and generated midl files from
IDL file during the build to check integrity.
Generated files during the build time and upstream generated files are
different because we use different IDL file(google_update_idl.idl) for google update.
So, we should copy our pre-installed files to overwrite upstream
pre-installed files.

Also, these files should not be the target of update_patches command.

issue: https://github.com/brave/brave-browser/issues/179

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
