### PR TITLE
add toggle for enable_distro_version_check

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -75,6 +75,7 @@ Config.prototype.buildArgs = function () {
     brave_version_minor: version_parts[1],
     brave_version_build: version_parts[2],
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
+    enable_distro_version_check: this.is_official_build,
   }
 
   if (process.platform === 'darwin') {


### PR DESCRIPTION
This turns off distro version checks for non-official builds

This is in reference to https://github.com/brave/brave-browser/issues/305

## Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).
- [X] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
Run a liux build with associated patches

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
