### PR TITLE
add uglifyjs-webpack-plugin as dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "less": "^2.7.3",
     "less-loader": "^4.0.5",
     "style-loader": "^0.19.1",
+    "uglifyjs-webpack-plugin": "^1.2.5",
     "url-loader": "^0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The current version of uglify we are using doesn't seem to properly support ES6 and wasn't properly transpiling brave-ui which targets ES6 as well.

This just adds the dependency, see https://github.com/brave/brave-core/pull/151 for the test plan and fix.

address #309

test plan: none