### PR TITLE
Provide a script to do GRD string upgrades for Chromium rebasing

### DIFF
--- a/lib/chromiumRebaseL10n.js
+++ b/lib/chromiumRebaseL10n.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const config = require('../lib/config')
+const util = require('../lib/util')
+const {rebaseBraveStringFilesOnChromiumL10nFiles} = require('./l10nUtil')
+
+const chromiumRebaseL10n = (options) => {
+  rebaseBraveStringFilesOnChromiumL10nFiles()
+}
+
+module.exports = chromiumRebaseL10n

--- a/lib/l10nUtil.js
+++ b/lib/l10nUtil.js
@@ -1,16 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 const path = require('path')
+const fs = require('fs')
+
 const srcDir = path.resolve(path.join(__dirname, '..', 'src'))
+
+// Brave string paths
+const braveStringsPath = path.resolve(path.join(srcDir, 'brave', 'app', 'brave_strings.grd'))
+const braveSettingsPartPath = path.resolve(path.join(srcDir, 'brave', 'app', 'settings_brave_strings.grdp'))
+const braveComponentsStringsPath = path.resolve(path.join(srcDir, 'brave', 'app', 'components_brave_strings.grd'))
+const braveExtensionMessagesPath = path.resolve(path.join(srcDir, 'brave', 'vendor', 'brave-extension', 'app', '_locales', 'en_US', 'messages.json'))
+const braveGeneratedResourcesPath = path.resolve(path.join(srcDir, 'brave', 'app', 'brave_generated_resources.grd'))
+const braveComponentsResourcesPath = path.resolve(path.join(srcDir, 'brave', 'components', 'resources', 'brave_components_resources.grd'))
+
+// Chromium string paths
+const chromiumStringsPath = path.resolve(path.join(srcDir, 'chrome', 'app', 'chromium_strings.grd'))
+const chroimumSettingsPartPath = path.resolve(path.join(srcDir, 'chrome', 'app', 'settings_chromium_strings.grdp'))
+const chromiumComponentsStringsPath = path.resolve(path.join(srcDir, 'components', 'components_chromium_strings.grd'))
 
 module.exports.getSourceStringPaths = () => {
   return [
-    path.resolve(path.join(srcDir, 'brave', 'vendor', 'brave-extension', 'app', '_locales', 'en_US', 'messages.json')),
-    path.resolve(path.join(srcDir, 'brave', 'app', 'brave_strings.grd')),
-    path.resolve(path.join(srcDir, 'brave', 'app', 'brave_generated_resources.grd')),
-    path.resolve(path.join(srcDir, 'brave', 'app', 'components_brave_strings.grd')),
-    path.resolve(path.join(srcDir, 'brave', 'components', 'resources', 'brave_components_resources.grd'))
+    braveStringsPath,
+    braveComponentsStringsPath,
+    braveExtensionMessagesPath,
+    braveGeneratedResourcesPath,
+    braveComponentsResourcesPath,
     // No strings for now, uncomment if strings are added
     // path.resolve(path.join(srcDir, 'brave', 'browser', 'resources', 'brave_extension.grd')),
     // path.resolve(path.join(srcDir, 'brave', 'common', 'extensions', 'api', 'brave_api_resources.grd')),
   ]
-
 }
+
+module.exports.rebaseBraveStringFilesOnChromiumL10nFiles = (path) =>
+  Object.entries({
+    [chromiumStringsPath]: braveStringsPath,
+    [chroimumSettingsPartPath]: braveSettingsPartPath,
+    [chromiumComponentsStringsPath]: braveComponentsStringsPath
+  }).forEach(([sourcePath, destPath]) =>
+    fs.writeFileSync(destPath,
+      fs.readFileSync(sourcePath, 'utf8')
+        .replace(/settings_chromium_strings.grdp/g, 'settings_brave_strings.grdp')
+        .replace(/The Chromium Authors/g, 'Brave Software Inc')
+        .replace(/Google Chrome/g, 'Brave')
+        .replace(/Chromium/g, 'Brave')
+        .replace(/Chrome/g, 'Brave')
+        .replace(/Google/g, 'Brave'), 'utf8'))

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "node ./scripts/commands.js start",
     "push_l10n": "node ./scripts/commands.js push_l10n",
     "pull_l10n": "node ./scripts/commands.js pull_l10n",
+    "chromium_rebase_l10n": "node ./scripts/commands.js chromium_rebase_l10n",
     "test": "node ./scripts/commands.js test",
     "web-ui": "webpack --config src/brave/components/webpack/prod.config.js --progress --profile --colors",
     "web-ui-dev": "webpack --config src/brave/components/webpack/dev.config.js --progress --profile --colors"

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 const program = require('commander');
 const path = require('path')
 const fs = require('fs-extra')
@@ -9,6 +13,7 @@ const start = require('../lib/start')
 const updatePatches = require('../lib/updatePatches')
 const pullL10n = require('../lib/pullL10n')
 const pushL10n = require('../lib/pushL10n')
+const chromiumRebaseL10n = require('../lib/chromiumRebaseL10n')
 const createDist = require('../lib/createDist')
 const upload = require('../lib/upload')
 const test = require('../lib/test')
@@ -72,6 +77,10 @@ program
 program
   .command('push_l10n')
   .action(pushL10n)
+
+program
+  .command('chromium_rebase_l10n')
+  .action(chromiumRebaseL10n)
 
 program
   .command('update_patches')


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/364

This replaces the following steps in the Brave wiki with a single command `npm run chromium_rebase_l10n`:

---

Chromium rebase wiki steps getting replaced:

```
cd brave
cp ../chrome/app/chromium_strings.grd app/brave_strings.grd
```

Open up `app/brave_strings.grd` and replace `settings_chromium_strings.grdp` with `settings_brave_strings.grdp`
Also apply these replacements:

```
%s/Google Chrome/Brave/g
%s/Chromium/Brave/g
%s/Chrome/Brave/g
%s/Google/Brave/g
%s/The Brave Authors. All rights reserved./Brave Software Inc. All rights reserved./g
%s/The Brave Authors/Brave Software Inc./g
```

`cp ../chrome/app/settings_chromium_strings.grdp app/settings_brave_strings.grdp`
Open up the file and apply these replacements:

```
%s/Google Chrome/Brave/g
%s/Chromium/Brave/g
%s/Chrome/Brave/g
%s/Google/Brave/g
```

`cp ../components/components_chromium_strings.grd ./app/components_brave_strings.grd`
Open up the file and apply these replacements:

```
%s/Google Chrome/Brave/g
%s/Chromium/Brave/g
%s/Chrome/Brave/g
%s/Google/Brave/g
```

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
