### PR TITLE
Introduce --touch_overridden_files option to build command

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,9 +1,57 @@
 const config = require('../lib/config')
 const util = require('../lib/util')
+const path = require('path')
+const fs = require('fs-extra')
+
+const touchOverriddenFiles = (filter) => {
+  console.log('touch original files overridden by chromium_src...')
+
+  // Return true when original file of |file| should be touched.
+  const applyFileFilter = (file) => {
+    // Exclude test files
+    if (file.indexOf('browsertest') > -1 || file.indexOf('unittest') > -1) { return false }
+
+    // Only includes cc and h files.
+    const ext = path.extname(file)
+    if (ext !== '.cc' && ext !== '.h') { return false }
+
+    // Touch all overridden files.
+    if (filter === '*') { return true }
+
+    return file.match(filter)
+  }
+
+  const walkSync = (dir, filelist = []) => {
+    fs.readdirSync(dir).forEach(file => {
+      if (fs.statSync(path.join(dir, file)).isDirectory()) {
+        filelist = walkSync(path.join(dir, file), filelist)
+      } else if (applyFileFilter(file)) {
+        filelist = filelist.concat(path.join(dir, file))
+      }
+    })
+    return filelist
+  }
+
+  const chromiumSrcDir = path.join(config.srcDir, 'brave', 'chromium_src')
+  var sourceFiles = walkSync(chromiumSrcDir)
+
+  // Touch original files by updating mtime.
+  const chromiumSrcDirLen = chromiumSrcDir.length
+  sourceFiles.forEach(file => {
+    const targetOriginalFile = path.join(config.srcDir, file.slice(chromiumSrcDirLen))
+    const date = new Date()
+    fs.utimesSync(targetOriginalFile, date, date)
+    console.log(targetOriginalFile + ' is touched.')
+  })
+}
 
 const build = (buildConfig = config.defaultBuildConfig, options) => {
   config.buildConfig = buildConfig
   config.update(options)
+
+  if (options.touch_overridden_files) {
+    touchOverriddenFiles(options.touch_overridden_files)
+  }
 
   if (!options.no_branding_update) {
     util.updateBranding()

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -37,6 +37,7 @@ program
   .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
   .option('--no_branding_update', 'don\'t copy BRANDING to the chrome theme dir')
   .option('--channel <target_chanel>', 'target channel to build', /^(beta|canary|dev|release)$/i, 'release')
+  .option('--touch_overridden_files <target filter>', 'touch original files overridden by chromium_src. Pass '*' to touch all files')
   .arguments('[build_config]')
   .action(build)
 


### PR DESCRIPTION
We sometimes copies upstream file in our chromium_src.
Then, our cc_wrapper scripts replaces original file with same file in chromium_src
if existed.
However, if we only modify copied file, gn doens't trigger rebuild
when original file isn't touched.

To fix this, use this option to touch original file.
To touch all overridden files, use --touch_overridden_files='*'.
To touch specific files contain specific strings, use --touch_overridden_files='manifest'.
This will touch original chrome_manifest_handlers.cc file.

Close https://github.com/brave/brave-browser/issues/352

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
