### PR TITLE
Fix "Gtk: cannot open display" error on Linux

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -17,11 +17,9 @@ const mergeWithDefault = (options) => {
 
 const util = {
   run: (cmd, args = [], options = {}) => {
-    if (!options.env) options.env = {}
     console.log(cmd, args.join(' '))
     const continueOnFail = options.continueOnFail
     delete options.continueOnFail
-
 
     const prog = spawnSync(cmd, args, options)
     if (prog.status !== 0) {


### PR DESCRIPTION
Fixes #385.

Chromium's GTK frontend requires the `$DISPLAY` environment variable to be set. `$DISPLAY` is set correctly by default in a graphical session on Ubuntu 16.04, but was not being inherited by the child process spawned in `util.run`. Environment variables should be inherited by default according to the child_process [docs](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options), but this behavior was broken by the following recent-ish change: https://github.com/brave/brave-browser/blob/7e590eb408da1ec5e1a079db42956a5b928ce16e/lib/util.js#L20

@RyanJarv Can you confirm that this PR does not otherwise break the intended behavior of #229, which introduced the bug? If it does, we'll need a more sophisticated fix. Generally I think we always want to inherit the environment in subprocesses spawned by the yarn scripts, since we/Chromium use environment variables (not just `$DISPLAY`) for a variety of purposes.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

Same as #385 STR.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
