### PR TITLE
Overwrite chrome/app/theme/chromium resources with ours

### DIFF
--- a/lib/updatePatches.js
+++ b/lib/updatePatches.js
@@ -16,7 +16,7 @@ const updatePatches = (options) => {
   let modifiedDiff = util.run('git', modifiedDiffArgs, runOptions)
   let moddedFileList = modifiedDiff.stdout.toString()
     .split('\n')
-    .filter(s => s.length > 0 && !s.endsWith('.xtb'))
+    .filter(s => s.length > 0 && !s.endsWith('.xtb') && !s.endsWith('.png'))
 
   let n = moddedFileList.length
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,6 +64,9 @@ const util = {
     fs.copySync(path.join(braveAppDir, 'theme', 'brave'), path.join(chromeAppDir, 'theme', 'brave'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_100_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_100_percent', 'brave'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_200_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_200_percent', 'brave'))
+    // By overwriting, we don't need to modify some grd files.
+    fs.copySync(path.join(braveAppDir, 'theme', 'default_100_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_100_percent', 'chromium'))
+    fs.copySync(path.join(braveAppDir, 'theme', 'default_200_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_200_percent', 'chromium'))
     fs.copySync(path.join(braveAppDir, 'vector_icons', 'brave'), path.join(chromeAppDir, 'vector_icons', 'brave'))
     // Copy XTB files for app/brave_strings.grd => chromium_strings.grd
     fs.copySync(path.join(braveAppDir, 'resources'), path.join(chromeAppDir, 'resources'))


### PR DESCRIPTION
By overwriting images, we can use our resources w/o changing grd file.
Also, png file shouldn't be included to patch set.

This PR is introduced for https://github.com/brave/brave-core/pull/158.
Related issue: https://github.com/brave/brave-browser/issues/317

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
