### PR TITLE
Disable use_jumbo_build for now

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -51,7 +51,9 @@ Config.prototype.buildArgs = function () {
   let args = {
     safe_browsing_mode: 1,
     root_extra_deps: [ "//brave" ],
-    use_jumbo_build: !this.officialBuild,
+    // TODO: Re-enable when chromium_src overrides work for files in relative
+    // paths like widevine_cmdm_compoennt_installer.cc
+    // use_jumbo_build: !this.officialBuild,
     is_component_build: this.buildConfig !== 'Release',
     proprietary_codecs: true,
     ffmpeg_branding: "Chrome",


### PR DESCRIPTION
Example: widevine_cmdm_compoennt_installer.cc is included in a generated jumbo .cc file via a relative path.

Fix https://github.com/brave/brave-browser/issues/411

It will be re-added eventually in https://github.com/brave/brave-browser/issues/410

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
