### PR TITLE
Revert "add toggle for enable_distro_version_check"

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -76,7 +76,6 @@ Config.prototype.buildArgs = function () {
     brave_version_minor: version_parts[1],
     brave_version_build: version_parts[2],
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
-    enable_distro_version_check: this.is_official_build,
   }
 
   if (process.platform === 'darwin') {


### PR DESCRIPTION
Reverts brave/brave-browser#306
Seeing the error below when building on mac and windows, reverting this PR fixes it.

```
yrliou@jocelyn-mbpr.local:~/brave$ yarn build
yarn run v1.3.2
$ node ./scripts/commands.js build
update branding...
building brave...
update omaha midl files...
gn gen /Users/yrliou/brave/src/out/Debug --args="safe_browsing_mode=1 root_extra_deps=[\"//brave\"] is_component_build=true proprietary_codecs=true ffmpeg_branding=\"Chrome\" enable_nacl=false enable_widevine=true target_cpu=\"x64\" is_official_build=false is_debug=true dcheck_always_on=true brave_channel=\"\" google_api_key=\"AIzaSyAH90V94EcZBP5oH7oc-mXQrSKgASVxER8\" brave_google_api_key=\"AIzaSyAQfxPJiounkhOjODEO5ZieffeBv6yft2Q\" brave_google_api_endpoint=\"https://www.googleapis.com/geolocation/v1/geolocate?key=\" brave_product_name=\"Brave\" brave_project_name=\"brave\" brave_version_major=\"0\" brave_version_minor=\"50\" brave_version_build=\"5\" safebrowsing_api_endpoint=\"safebrowsing.brave.com\" enable_distro_version_check=undefined mac_signing_identifier=\"\" mac_signing_keychain=\"login\" enable_stripping=false symbol_level=2 enable_profiling=true is_win_fastlink=true cc_wrapper=\"/Users/yrliou/brave/src/brave/script/redirect-cc.py\" "
ERROR at the command-line "--args":1:667: Undefined identifier
safe_browsing_mode=1 root_extra_deps=["//brave"] is_component_build=true proprietary_codecs=true ffmpeg_branding="Chrome" enable_nacl=false enable_widevine=true target_cpu="x64" is_official_build=false is_debug=true dcheck_always_on=true brave_channel="" google_api_key="AIzaSyAH90V94EcZBP5oH7oc-mXQrSKgASVxER8" brave_google_api_key="AIzaSyAQfxPJiounkhOjODEO5ZieffeBv6yft2Q" brave_google_api_endpoint="https://www.googleapis.com/geolocation/v1/geolocate?key=" brave_product_name="Brave" brave_project_name="brave" brave_version_major="0" brave_version_minor="50" brave_version_build="5" safebrowsing_api_endpoint="safebrowsing.brave.com" enable_distro_version_check=undefined mac_signing_identifier="" mac_signing_keychain="login" enable_stripping=false symbol_level=2 enable_profiling=true is_win_fastlink=true cc_wrapper="/Users/yrliou/brave/src/brave/script/redirect-cc.py"
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          ^--------
null
null
error Command failed with exit code 1.
```

cc @bkero 