### PR TITLE
Touch overridden files automatically

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -3,7 +3,7 @@ const util = require('../lib/util')
 const path = require('path')
 const fs = require('fs-extra')
 
-const touchOverriddenFiles = (filter) => {
+const touchOverriddenFiles = () => {
   console.log('touch original files overridden by chromium_src...')
 
   // Return true when original file of |file| should be touched.
@@ -15,10 +15,7 @@ const touchOverriddenFiles = (filter) => {
     const ext = path.extname(file)
     if (ext !== '.cc' && ext !== '.h' && ext !== '.mm') { return false }
 
-    // Touch all overridden files.
-    if (filter === '*') { return true }
-
-    return file.match(filter)
+    return true
   }
 
   const walkSync = (dir, filelist = []) => {
@@ -37,11 +34,21 @@ const touchOverriddenFiles = (filter) => {
 
   // Touch original files by updating mtime.
   const chromiumSrcDirLen = chromiumSrcDir.length
-  sourceFiles.forEach(file => {
-    const targetOriginalFile = path.join(config.srcDir, file.slice(chromiumSrcDirLen))
-    const date = new Date()
-    fs.utimesSync(targetOriginalFile, date, date)
-    console.log(targetOriginalFile + ' is touched.')
+  sourceFiles.forEach(chromiumSrcFile => {
+    var overriddenFile = path.join(config.srcDir, chromiumSrcFile.slice(chromiumSrcDirLen))
+    if (!fs.existsSync(overriddenFile)) {
+      // Try to check that original file is in gen dir.
+      overriddenFile = path.join(config.outputDir, 'gen', chromiumSrcFile.slice(chromiumSrcDirLen))
+    }
+
+    if (fs.existsSync(overriddenFile)) {
+      // If overriddenFile is older than file in chromium_src, touch it to trigger rebuild.
+      if (fs.statSync(chromiumSrcFile).mtimeMs - fs.statSync(overriddenFile).mtimeMs > 0) {
+        const date = new Date()
+        fs.utimesSync(overriddenFile, date, date)
+        console.log(overriddenFile + ' is touched.')
+      }
+    }
   })
 }
 
@@ -49,9 +56,7 @@ const build = (buildConfig = config.defaultBuildConfig, options) => {
   config.buildConfig = buildConfig
   config.update(options)
 
-  if (options.touch_overridden_files) {
-    touchOverriddenFiles(options.touch_overridden_files)
-  }
+  touchOverriddenFiles()
 
   if (!options.no_branding_update) {
     util.updateBranding()

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -37,7 +37,6 @@ program
   .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
   .option('--no_branding_update', 'don\'t copy BRANDING to the chrome theme dir')
   .option('--channel <target_chanel>', 'target channel to build', /^(beta|dev|nightly|release)$/i, 'release')
-  .option('--touch_overridden_files <target filter>', 'touch original files overridden by chromium_src. Pass '*' to touch all files')
   .arguments('[build_config]')
   .action(build)
 


### PR DESCRIPTION
As @bridiver 's comment(https://github.com/brave/brave-browser/pull/371#issuecomment-398268762), touching automatically would be much better than by using options.

Touch overridden file automatically when it is older than file in chromium_src.

Issue https://github.com/brave/brave-browser/issues/352
Close https://github.com/brave/brave-browser/issues/434

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
