### PR TITLE
Revert "add optional cache for cloning repos"

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -27,7 +27,6 @@ const Config = function () {
   this.defaultGClientFile = path.join(this.rootDir, '.gclient')
   this.gClientFile = process.env.BRAVE_GCLIENT_FILE || this.defaultGClientFile
   this.gClientVerbose = getNPMConfig(['gclient_verbose']) || false
-  this.gClientCacheDir = getNPMConfig(['gclient_cachedir']) || false
   this.targetArch = 'x64'
   this.gypTargetArch = 'x64'
   this.officialBuild = true
@@ -250,9 +249,6 @@ Config.prototype.update = function (options) {
 
   if (options.gclient_verbose)
     this.gClientVerbose = options.gclient_verbose
-
-  if (options.gclient_cachedir)
-    this.gClientCacheDir = options.gclient_cachedir
 
   this.projectNames.forEach((projectName) => {
     // don't update refs for projects that have them

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,7 +5,6 @@ const fs = require('fs-extra')
 
 const runGClient = (args, options = {}) => {
   if (config.gClientVerbose) args.push('--verbose')
-  if (config.gClientCacheDir) args.push('--cache-dir=' + config.gClientCacheDir)
   options.cwd = options.cwd || config.rootDir
   options = mergeWithDefault(options)
   options.env.GCLIENT_FILE = config.gClientFile
@@ -48,9 +47,7 @@ const util = {
       }
     })
 
-    let out = ''
-    if (config.gClientCacheDir) cache_dir_line = 'cache_dir = "' + config.gClientCacheDir + '"\n'
-    out += 'solutions = ' + JSON.stringify(solutions, replacer, 2)
+    const out = 'solutions = ' + JSON.stringify(solutions, replacer, 2)
       .replace(/"%None%"/g, "None")
       .replace(/"%False%"/g, "False")
     fs.writeFileSync(config.defaultGClientFile, out)
@@ -120,7 +117,7 @@ const util = {
   },
 
   gclientSync: (options = {}) => {
-    runGClient(['sync', '--force', '--nohooks', '--with_branch_heads', '--with_tags'], options)
+    runGClient(['sync', '--force', '--nohooks', '--with_branch_heads'], options)
   },
 
   gclientRunhooks: (options = {}) => {

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -10,7 +10,6 @@ program
   .version(process.env.npm_package_version)
   .option('--gclient_file <file>', 'gclient config file location')
   .option('--gclient_verbose', 'verbose output for gclient')
-  .option('--gclient_cachedir <directory>', 'cache directory of git mirrors for gclient')
   .option('--run_hooks', 'run gclient hooks')
   .option('--run_sync', 'run gclient sync')
   .option('--submodule_sync', 'run submodule sync')


### PR DESCRIPTION
This reverts commit 6c2176eee55bb9ef5dc52d655225d8129df36435.

This is necessary because chromium removed the `--cache-dir` option from gclient in favor of an environment variable [1]. This means we no longer need to pass this through to the build system -- an environment variable will do just as well.

[1] https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/1105473

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
