### PR TITLE
Update app icon of stable/development version on linux

### DIFF
--- a/lib/updatePatches.js
+++ b/lib/updatePatches.js
@@ -16,8 +16,8 @@ const updatePatches = (options) => {
   let modifiedDiff = util.run('git', modifiedDiffArgs, runOptions)
   let moddedFileList = modifiedDiff.stdout.toString()
     .split('\n')
-    .filter(s => s.length > 0 && !s.endsWith('.xtb') && !s.endsWith('.png') &&
-            !s.endsWith('.grd') && !s.endsWith('.grdp') &&
+    .filter(s => s.length > 0 && !s.startsWith(path.join('chrome', 'app', 'theme')) &&
+            !s.endsWith('.xtb') && !s.endsWith('.grd') && !s.endsWith('.grdp') &&
             !s.includes('google_update_idl'))
 
   let n = moddedFileList.length

--- a/lib/util.js
+++ b/lib/util.js
@@ -79,6 +79,7 @@ const util = {
     fs.copySync(path.join(braveAppDir, 'theme', 'default_100_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_100_percent', 'brave'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_200_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_200_percent', 'brave'))
     // By overwriting, we don't need to modify some grd files.
+    fs.copySync(path.join(braveAppDir, 'theme', 'brave'), path.join(chromeAppDir, 'theme', 'chromium'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_100_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_100_percent', 'chromium'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_200_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_200_percent', 'chromium'))
     fs.copySync(path.join(braveAppDir, 'vector_icons', 'brave'), path.join(chromeAppDir, 'vector_icons', 'brave'))


### PR DESCRIPTION
Overwrite chrome/app/theme/chromium with brave/app/theme/brave.

With this, app icon of stable/development version ues ours.
chrome/app/theme path is excluded from updatePatches.

Issue https://github.com/brave/brave-browser/issues/10

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
`yarn start` for checking app icon for dev.
`yarn start Release` for checking app icon for stable.
`export CHROME_VERSION_EXTRA=dev; yarn start Release` for checking app icon for dev.
`export CHROME_VERSION_EXTRA=beta; yarn start Release` for checking app icon for beta.


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
