### PR TITLE
Skip rename method of linux dist

### DIFF
--- a/lib/createDist.js
+++ b/lib/createDist.js
@@ -14,8 +14,6 @@ const createDist = (buildConfig = config.defaultBuildConfig, options) => {
   fs.removeSync(path.join(config.outputDir, 'dist'))
   config.buildTarget = 'create_dist'
   util.buildTarget()
-
-  renameLinuxDistr(options)
 }
 
 const renameLinuxDistr = (options) => {


### PR DESCRIPTION
Current rename method just removes non-stable dist package file.

Need to re-enable that method when we determine final name of dist package name.

issue https://github.com/brave/brave-browser/issues/396

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
