### PR TITLE
Don't create patch files under chrome/app/theme

### DIFF
--- a/lib/updatePatches.js
+++ b/lib/updatePatches.js
@@ -16,7 +16,7 @@ const updatePatches = (options) => {
   let modifiedDiff = util.run('git', modifiedDiffArgs, runOptions)
   let moddedFileList = modifiedDiff.stdout.toString()
     .split('\n')
-    .filter(s => s.length > 0 && !s.startsWith(path.join('chrome', 'app', 'theme')) &&
+    .filter(s => s.length > 0 && !s.startsWith('chrome/app/theme') &&
             !s.endsWith('.xtb') && !s.endsWith('.grd') && !s.endsWith('.grdp') &&
             !s.includes('google_update_idl'))
 


### PR DESCRIPTION
Changed file list uses '/' separator.
However, result from path.join() on Windows uses '\' separator.
Because of this difference, files in chrome/app/theme are not excluded.

Close https://github.com/brave/brave-browser/issues/465

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
