### PR TITLE
Fix product_logo in chrome://versions and default_browser_infobar

### DIFF
--- a/lib/updatePatches.js
+++ b/lib/updatePatches.js
@@ -22,7 +22,8 @@ const updatePatches = (options) => {
   const modifiedFileList = modifiedDiff.stdout.toString()
     .split('\n')
     .filter(s => s.length > 0 && !s.startsWith('chrome/app/theme') &&
-            !s.endsWith('.xtb') && !s.endsWith('.grd') && !s.endsWith('.grdp') &&
+            !s.endsWith('.png') && !s.endsWith('.xtb') &&
+            !s.endsWith('.grd') && !s.endsWith('.grdp') &&
             !s.includes('google_update_idl'))
 
   // copy array

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,6 +56,7 @@ const util = {
   updateBranding: () => {
     console.log('update branding...')
     const chromeComponentsDir = path.join(config.srcDir, 'components')
+    const braveComponentsDir = path.join(config.projects['brave-core'].dir, 'components')
     const chromeAppDir = path.join(config.srcDir, 'chrome', 'app')
     const braveAppDir = path.join(config.projects['brave-core'].dir, 'app')
     const chromeResourcesDir = path.join(config.srcDir, 'chrome', 'browser', 'resources')
@@ -83,6 +84,8 @@ const util = {
     fs.copySync(path.join(braveAppDir, 'theme', 'brave'), path.join(chromeAppDir, 'theme', 'chromium'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_100_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_100_percent', 'chromium'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_200_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_200_percent', 'chromium'))
+    fs.copySync(path.join(braveComponentsDir, 'resources', 'default_100_percent', 'brave'), path.join(chromeComponentsDir, 'resources', 'default_100_percent', 'chromium'))
+    fs.copySync(path.join(braveComponentsDir, 'resources', 'default_200_percent', 'brave'), path.join(chromeComponentsDir, 'resources', 'default_200_percent', 'chromium'))
     fs.copySync(path.join(braveAppVectorIconsDir, 'vector_icons', 'brave'), path.join(chromeAppDir, 'vector_icons', 'brave'))
     // Copy XTB files for app/brave_strings.grd => chromium_strings.grd
     fs.copySync(path.join(braveAppDir, 'resources'), path.join(chromeAppDir, 'resources'))

--- a/lib/util.js
+++ b/lib/util.js
@@ -62,6 +62,7 @@ const util = {
     const braveResourcesDir = path.join(config.projects['brave-core'].dir, 'browser', 'resources')
     const chromeBrowserDir = path.join(config.srcDir, 'chrome', 'browser')
     const braveBrowserDir = path.join(config.projects['brave-core'].dir, 'browser')
+    const braveAppVectorIconsDir = path.join(config.projects['brave-core'].dir, 'vector_icons', 'chrome', 'app')
 
     fs.copySync(path.join(braveAppDir, 'brave_strings.grd'), path.join(chromeAppDir, 'brave_strings.grd'))
     fs.copySync(path.join(braveAppDir, 'settings_brave_strings.grdp'), path.join(chromeAppDir, 'settings_brave_strings.grdp'))
@@ -82,7 +83,7 @@ const util = {
     fs.copySync(path.join(braveAppDir, 'theme', 'brave'), path.join(chromeAppDir, 'theme', 'chromium'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_100_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_100_percent', 'chromium'))
     fs.copySync(path.join(braveAppDir, 'theme', 'default_200_percent', 'brave'), path.join(chromeAppDir, 'theme', 'default_200_percent', 'chromium'))
-    fs.copySync(path.join(braveAppDir, 'vector_icons', 'brave'), path.join(chromeAppDir, 'vector_icons', 'brave'))
+    fs.copySync(path.join(braveAppVectorIconsDir, 'vector_icons', 'brave'), path.join(chromeAppDir, 'vector_icons', 'brave'))
     // Copy XTB files for app/brave_strings.grd => chromium_strings.grd
     fs.copySync(path.join(braveAppDir, 'resources'), path.join(chromeAppDir, 'resources'))
     // Copy XTB files for brave/app/components_brave_strings.grd => components/components_chromium_strings.grd


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/519
Please see https://github.com/brave/brave-core/pull/240 for more info.
Will need to be merged together with above.
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
