### PR TITLE
Disable software update by default when yarn start

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -19,6 +19,10 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   if (options.disable_pdfjs_extension) {
     braveArgs.push('--disable-pdfjs-extension')
   }
+  if (!options.enable_brave_update) {
+    // This only has meaning with MacOS and official build.
+    braveArgs.push('--disable-brave-update')
+  }
 
   let cmdOptions = {
     stdio: 'inherit',

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -67,6 +67,7 @@ program
   .option('--no_sandbox', 'disable the sandbox')
   .option('--disable_brave_extension', 'disable loading the Brave extension')
   .option('--disable_pdfjs_extension', 'disable loading the PDFJS extension')
+  .option('--enable_brave_update', 'enable brave update')
   .arguments('[build_config]')
   .action(start)
 


### PR DESCRIPTION
On MacOSX, update is triggered in official build.
On Windows, however, it isn't.

Close https://github.com/brave/brave-browser/issues/575

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:

Check `--disable-brave-update` is attached when `yarn start` without `--enable_brave_update`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
