### PR TITLE
Bump patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave",
-  "version": "0.50.11",
+  "version": "0.50.13",
   "description": "Next generation Brave browser for macOS, Windows, Linux, and eventually Android",
   "scripts": {
     "cibuild": "node ./scripts/commands.js cibuild",


### PR DESCRIPTION
Skipping 12 because it was used for some ad-hoc testing, also 13 == good luck