### PR TITLE
Fix browser test crash on MacOS due to sparkle initialization

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -10,6 +10,7 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
   const braveArgs = [
     '--enable-logging',
     '--v=' + options.v,
+    '--disable-brave-update',
   ]
 
   if (options.filter) {


### PR DESCRIPTION
Issue: https://github.com/brave/brave-browser/issues/590
In browser tests, sparkle framework shouldn't be initialized.

# Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:
`yarn test brave_browser_tests Release` w/o crash

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
