### PR TITLE
Don't need to try rename the unstable named deb/rpm files

### DIFF
--- a/lib/createDist.js
+++ b/lib/createDist.js
@@ -14,25 +14,6 @@ const createDist = (buildConfig = config.defaultBuildConfig, options) => {
   fs.removeSync(path.join(config.outputDir, 'dist'))
   config.buildTarget = 'create_dist'
   util.buildTarget()
-
-  renameLinuxDistr(options)
-}
-
-const renameLinuxDistr = (options) => {
-  if (process.platform === 'linux') {
-    fs.readdir(config.outputDir, function(err, items) {
-      for (var i=0; i<items.length; i++) {
-        var newFileName = '';
-        if ((new RegExp(/brave-browser-unstable.*[rpm|dep].*$/)).test(items[i])) {
-          newFileName = items[i].replace('unstable', 'dev')
-        }
-        if (newFileName) {
-          fs.renameSync(path.join(config.outputDir, items[i]),
-            path.join(config.outputDir, newFileName))
-        }
-      }
-    })
-  }
 }
 
 module.exports = createDist


### PR DESCRIPTION
We don't make unstable named outputs anymore

#issue https://github.com/brave/brave-browser/issues/582

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
