### PR TITLE
Revert "Fix browser test crash on MacOS due to sparkle initialization"

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -10,7 +10,6 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
   const braveArgs = [
     '--enable-logging',
     '--v=' + options.v,
-    '--disable-brave-update',
   ]
 
   if (options.filter) {


### PR DESCRIPTION
Reverts brave/brave-browser#593

This can be reverted because browser can check sparkle updater is enabled or not in runtime.
In this commit(https://github.com/brave/brave-core/pull/271/commits/f8cf51c6755dd5718303e874408c9108fbab9d1c), runtime detection is implemented.

This can be merged after https://github.com/brave/brave-core/pull/271 is merged.