### PR TITLE
Bump versions 0.54.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brave",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brave",
-  "version": "0.50.15",
+  "version": "0.53.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave",
-  "version": "0.50.16",
+  "version": "0.53.0",
   "description": "Next generation Brave browser for macOS, Windows, Linux, and eventually Android",
   "scripts": {
     "cibuild": "node ./scripts/commands.js cibuild",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Next generation Brave browser for macOS, Windows, Linux, and eventually Android",
   "scripts": {
     "cibuild": "node ./scripts/commands.js cibuild",


### PR DESCRIPTION
Related: https://github.com/brave/brave-core/pull/282

We need to do a branch for 0.53.x so setting this up in 2 commits, one will go to the 0.53.x branch and the other one won't. '
https://github.com/brave/brave-browser/wiki/Brave-Release-Schedule