### PR TITLE
Modify build settings to allow sccache support on Windows

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -92,6 +92,15 @@ Config.prototype.buildArgs = function () {
     args.is_win_fastlink = true
   }
 
+  if (!this.officialBuild && process.platform === 'win32') {
+    let sccache = getNPMConfig(['sccache'])
+    if (sccache) {
+      args.clang_use_chrome_plugins = false
+      args.enable_precompiled_headers = false
+    }
+    args.use_thin_lto = true
+  }
+
   if (this.targetArch === 'x86' && process.platform === 'linux') {
     // Minimal symbols for target Linux x86, because ELF32 cannot be > 4GiB
     args.symbol_level = 1


### PR DESCRIPTION
This PR modifies the build settings to allow using sccache on Windows. Three changes were required:

1. Don't pass the `-XClang find-bad-constructs` arg, as sccache incorrectly interprets the argument as an additional source file on Windows. We accomplish this by disabling `clang_use_chrome_plugins`.
1. Don't pass `/Brepro`, as it causes the following error when compiling with sccache enabled: `warning: argument unused during compilation: '-mno-incremental-linker-compatible'`. We accomplish this by enabling `use_thin_lto`.
1. Don't pass /Fp, as this setting seems to conflict with sccache. We accomplish this by setting `enable_precompiled_headers` to false.
---
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
