### PR TITLE
delete .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["es2015", "stage-0", "react"],
-  "plugins": ["add-module-exports", "transform-decorators-legacy", "transform-runtime"]
-}


### PR DESCRIPTION
move `.babelrc` from `brave-browser/.babelrc` to `brave-browser/src/brave/.babelrc` because babel expects to find own modules like `node_modules/babel-xxxxxx` in a folder near `.babelrc` file. `node_modules/babel-core/lib/transformation/file/options/build-config-chain.js` .

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
