### PR TITLE
Don't set CC_WRAPPER if current build settings don't support sccache

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -43,6 +43,7 @@ const Config = function () {
   this.mac_signing_identifier = getNPMConfig(['mac_signing_identifier']) || ''
   this.mac_signing_keychain = getNPMConfig(['mac_signing_keychain']) || 'login'
   this.channel = ''
+  this.sccache = getNPMConfig(['sccache'])
 }
 
 Config.prototype.buildArgs = function () {
@@ -94,12 +95,9 @@ Config.prototype.buildArgs = function () {
     args.is_win_fastlink = true
   }
 
-  if (!this.officialBuild && process.platform === 'win32') {
-    let sccache = getNPMConfig(['sccache'])
-    if (sccache) {
-      args.clang_use_chrome_plugins = false
-      args.enable_precompiled_headers = false
-    }
+  if (this.sccache && process.platform === 'win32') {
+    args.clang_use_chrome_plugins = false
+    args.enable_precompiled_headers = false
     args.use_thin_lto = true
   }
 
@@ -107,14 +105,6 @@ Config.prototype.buildArgs = function () {
     // Minimal symbols for target Linux x86, because ELF32 cannot be > 4GiB
     args.symbol_level = 1
   }
-
-  // TODO: Build redirect-cc.cmd in such a way that it still works with ccache if configured
-  /*
-  let sccache = getNPMConfig(['sccache'])
-  if (sccache) {
-    args.cc_wrapper = sccache
-  }
-  */
 
   if (process.platform === 'win32') {
     args.cc_wrapper = path.join(this.srcDir, 'brave', 'script' ,'redirect-cc.cmd')
@@ -289,9 +279,8 @@ Object.defineProperty(Config.prototype, 'defaultOptions', {
     env.TARGET_ARCH = this.gypTargetArch // for brave scripts
     env.GYP_MSVS_VERSION = env.GYP_MSVS_VERSION || '2017' // enable 2017
 
-    let sccache = getNPMConfig(['sccache'])
-    if (sccache) {
-      env.CC_WRAPPER = sccache
+    if (this.sccache) {
+      env.CC_WRAPPER = this.sccache
     }
 
     if (process.platform === 'linux') {


### PR DESCRIPTION
On Windows, we currently only support sccache for non-official
builds. This fix allows you to keep sccache enabled in your .npmrc and
it will be used when it's allowed and not used when its disallowed.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
