### PR TITLE
Copy proper app icon to /chrome/app/theme/mac/app.icns

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -239,9 +239,12 @@ Config.prototype.update = function (options) {
     this.officialBuild = this.buildConfig === 'Release'
   }
 
-  // In chromium src, empty string represents stable channel.
-  if (options.channel !== 'release')
+  if (this.debugBuild) {
+    this.channel = 'development'
+  } else if (options.channel !== 'release') {
+    // In chromium src, empty string represents stable channel.
     this.channel = options.channel
+  }
 
   if (options.mac_signing_identifier)
     this.mac_signing_identifier = options.mac_signing_identifier

--- a/lib/util.js
+++ b/lib/util.js
@@ -93,6 +93,14 @@ const util = {
     fs.copySync(path.join(braveComponentsDir, 'resources', 'default_200_percent', 'brave'), path.join(chromeComponentsDir, 'resources', 'default_200_percent', 'chromium'))
     fs.copySync(path.join(braveAppVectorIconsDir, 'vector_icons', 'brave'), path.join(chromeAppDir, 'vector_icons', 'brave'))
     fs.copySync(path.join(braveResourcesDir, 'settings', 'brave_page_visibility.js'), path.join(chromeResourcesDir, 'settings', 'brave_page_visibility.js'))
+
+    if (process.platform === 'darwin') {
+      // Copy proper mac app icon for channel to chrome/app/theme/mac/app.icns.
+      // Each channel's app icons are stored in brave/app/theme/$channel/app.icns.
+      // With this copying, we don't need to modify chrome/BUILD.gn for this.
+      fs.copySync(path.join(braveAppDir, 'theme', 'brave', 'mac', config.channel, 'app.icns'),
+                  path.join(chromeAppDir, 'theme', 'brave', 'mac', 'app.icns'))
+    }
   },
 
   // Chromium compares pre-installed midl files and generated midl files from IDL during the build to check integrity.


### PR DESCRIPTION
With this, we can avoid patching chrome/BUILD.gn for this.

issue: https://github.com/brave/brave-browser/issues/652

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
