### PR TITLE
Enable different channel apps run simultaneously on MacOS

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -30,7 +30,12 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   }
 
   if (process.platform === 'darwin') {
-    util.run(path.join(config.outputDir, 'Brave.app', 'Contents', 'MacOS', 'Brave'), braveArgs, cmdOptions)
+    let product_name = 'Brave-Browser'
+    if (config.channel) {
+      // Capitalize channel name and append it to make product name like Brave-Browser-Beta
+      product_name = product_name + '-' + config.channel.charAt(0).toUpperCase() + config.channel.slice(1)
+    }
+    util.run(path.join(config.outputDir, product_name + '.app', 'Contents', 'MacOS', product_name), braveArgs, cmdOptions)
   } else if (process.platform === 'win32') {
     util.run(path.join(config.outputDir, 'brave.exe'), braveArgs, cmdOptions)
   } else {

--- a/lib/util.js
+++ b/lib/util.js
@@ -100,6 +100,12 @@ const util = {
       // With this copying, we don't need to modify chrome/BUILD.gn for this.
       fs.copySync(path.join(braveAppDir, 'theme', 'brave', 'mac', config.channel, 'app.icns'),
                   path.join(chromeAppDir, 'theme', 'brave', 'mac', 'app.icns'))
+
+      // Copy branding file
+      let branding_file_name = 'BRANDING'
+      if (config.channel)
+        branding_file_name = branding_file_name + '.' + config.channel
+      fs.copySync(path.join(braveAppDir, 'theme', 'brave', branding_file_name), path.join(chromeAppDir, 'theme', 'brave', 'BRANDING'))
     }
   },
 

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -68,6 +68,7 @@ program
   .option('--disable_brave_extension', 'disable loading the Brave extension')
   .option('--disable_pdfjs_extension', 'disable loading the PDFJS extension')
   .option('--enable_brave_update', 'enable brave update')
+  .option('--channel <target_chanel>', 'target channel to start', /^(beta|dev|nightly|release)$/i, 'release')
   .arguments('[build_config]')
   .action(start)
 


### PR DESCRIPTION
Use different BRANDING file for different channel because Brave on
MacOS utilizes BRANDING file to get unique app name and id.
To do this, copy channel specific branding file such as BRANDING.beta to BRANDING.

Add channel option to start command because each channel app uses
different app name.

issue: https://github.com/brave/brave-browser/issues/469

This PR should be merged together with https://github.com/brave/brave-core/pull/298.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions
