### PR TITLE
Cleanup: Move mac app name generation from start.js to config.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -270,6 +270,17 @@ Config.prototype.update = function (options) {
   })
 }
 
+if (process.platform === 'darwin') {
+  Config.prototype.macAppName = function () {
+    let app_name = 'Brave-Browser'
+    if (this.channel) {
+      // Capitalize channel name and append it to make app name like Brave-Browser-Beta
+      app_name = app_name + '-' + this.channel.charAt(0).toUpperCase() + this.channel.slice(1)
+    }
+    return app_name
+  }
+}
+
 Object.defineProperty(Config.prototype, 'defaultOptions', {
   get: function () {
     let env = Object.assign({}, process.env)

--- a/lib/start.js
+++ b/lib/start.js
@@ -30,12 +30,7 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   }
 
   if (process.platform === 'darwin') {
-    let product_name = 'Brave-Browser'
-    if (config.channel) {
-      // Capitalize channel name and append it to make product name like Brave-Browser-Beta
-      product_name = product_name + '-' + config.channel.charAt(0).toUpperCase() + config.channel.slice(1)
-    }
-    util.run(path.join(config.outputDir, product_name + '.app', 'Contents', 'MacOS', product_name), braveArgs, cmdOptions)
+    util.run(path.join(config.outputDir, config.macAppName() + '.app', 'Contents', 'MacOS', config.macAppName()), braveArgs, cmdOptions)
   } else if (process.platform === 'win32') {
     util.run(path.join(config.outputDir, 'brave.exe'), braveArgs, cmdOptions)
   } else {


### PR DESCRIPTION
follow up PR for https://github.com/brave/brave-browser/pull/659#discussion_r208697481

issue: #469

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
