### PR TITLE
Introduce npm run lint command for cpp formatting

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,0 +1,7 @@
+const util = require('../lib/util')
+
+const lint = (options = {}) => {
+  util.lint()
+}
+
+module.exports = lint

--- a/lib/util.js
+++ b/lib/util.js
@@ -131,6 +131,15 @@ const util = {
     util.run('ninja', ['-C', config.outputDir, config.buildTarget], options)
   },
 
+  lint: (options = {}) => {
+    console.log('linting ' + config.projects['brave-core'].dir  + '...')
+    options.cwd = config.projects['brave-core'].dir
+    options = mergeWithDefault(options)
+    // git cl format checks rietveld.server is set. Just set null.
+    util.run('git', ['config', 'rietveld.server', 'null'], options)
+    util.run('git', ['cl', 'format'], options)
+  },
+
   submoduleSync: (options = {}) => {
     if (!options.cwd) options.cwd = config.rootDir // default cwd `./src` may not exist yet
     options = mergeWithDefault(options)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "push_l10n": "node ./scripts/commands.js push_l10n",
     "pull_l10n": "node ./scripts/commands.js pull_l10n",
     "chromium_rebase_l10n": "node ./scripts/commands.js chromium_rebase_l10n",
-    "test": "node ./scripts/commands.js test"
+    "test": "node ./scripts/commands.js test",
+    "lint": "node ./scripts/commands.js lint"
   },
   "config": {
     "projects": {

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -17,6 +17,7 @@ const chromiumRebaseL10n = require('../lib/chromiumRebaseL10n')
 const createDist = require('../lib/createDist')
 const upload = require('../lib/upload')
 const test = require('../lib/test')
+const lint = require('../lib/lint')
 
 program
   .version(process.env.npm_package_version)
@@ -104,6 +105,10 @@ program
   .option('--single_process', 'uses a single process to run tests to help with debugging')
   .arguments('[build_config]')
   .action(test)
+
+program
+  .command('lint')
+  .action(lint)
 
 program
   .parse(process.argv)


### PR DESCRIPTION
This command automatically formats a pending patch of brave core according to Chromium style.
See documents about `git cl format` : https://chromium.googlesource.com/chromium/src/+/lkcr/docs/clang_format.md

close https://github.com/brave/brave-browser/issues/116

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
run `yarn lint` after making changes in brave-core.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
