### PR TITLE
Add ability to start single process and add ability to start unofficial Release builds on macOS

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -241,7 +241,7 @@ Config.prototype.update = function (options) {
     this.officialBuild = this.buildConfig === 'Release'
   }
 
-  if (this.debugBuild) {
+  if (!this.officialBuild) {
     this.channel = 'development'
   } else if (options.channel !== 'release') {
     // In chromium src, empty string represents stable channel.

--- a/lib/start.js
+++ b/lib/start.js
@@ -23,6 +23,9 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
     // This only has meaning with MacOS and official build.
     braveArgs.push('--disable-brave-update')
   }
+  if (options.single_process) {
+    braveArgs.push('--single-process')
+  }
 
   let cmdOptions = {
     stdio: 'inherit',

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -69,6 +69,7 @@ program
   .option('--disable_pdfjs_extension', 'disable loading the PDFJS extension')
   .option('--enable_brave_update', 'enable brave update')
   .option('--channel <target_chanel>', 'target channel to start', /^(beta|dev|nightly|release)$/i, 'release')
+  .option('--single_process', 'use a single process')
   .arguments('[build_config]')
   .action(start)
 

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -69,6 +69,7 @@ program
   .option('--disable_pdfjs_extension', 'disable loading the PDFJS extension')
   .option('--enable_brave_update', 'enable brave update')
   .option('--channel <target_chanel>', 'target channel to start', /^(beta|dev|nightly|release)$/i, 'release')
+  .option('--official_build <official_build>', 'force official build settings')
   .option('--single_process', 'use a single process')
   .arguments('[build_config]')
   .action(start)


### PR DESCRIPTION
Fix #753
Fix #754 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
