### PR TITLE
Touch overridden icon files when our icon file is updated

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -52,6 +52,46 @@ const touchOverriddenFiles = () => {
   })
 }
 
+const touchOverriddenVectorIconFiles = () => {
+  console.log('touch original vector icon files overridden by brave/vector_icons...')
+
+  // Return true when original file of |file| should be touched.
+  const applyFileFilter = (file) => {
+    // Only includes icon files.
+    const ext = path.extname(file)
+    if (ext !== '.icon') { return false }
+    return true
+  }
+
+  const walkSync = (dir, filelist = []) => {
+    fs.readdirSync(dir).forEach(file => {
+      if (fs.statSync(path.join(dir, file)).isDirectory()) {
+        filelist = walkSync(path.join(dir, file), filelist)
+      } else if (applyFileFilter(file)) {
+        filelist = filelist.concat(path.join(dir, file))
+      }
+    })
+    return filelist
+  }
+
+  const braveVectorIconsDir = path.join(config.srcDir, 'brave', 'vector_icons')
+  var braveVectorIconFiles = walkSync(braveVectorIconsDir)
+
+  // Touch original files by updating mtime.
+  const braveVectorIconsDirLen = braveVectorIconsDir.length
+  braveVectorIconFiles.forEach(braveVectorIconFile => {
+    var overriddenFile = path.join(config.srcDir, braveVectorIconFile.slice(braveVectorIconsDirLen))
+    if (fs.existsSync(overriddenFile)) {
+      // If overriddenFile is older than file in vector_icons, touch it to trigger rebuild.
+      if (fs.statSync(braveVectorIconFile).mtimeMs - fs.statSync(overriddenFile).mtimeMs > 0) {
+        const date = new Date()
+        fs.utimesSync(overriddenFile, date, date)
+        console.log(overriddenFile + ' is touched.')
+      }
+    }
+  })
+}
+
 /**
  * Checks to make sure the src/chrome/VERSION matches brave-browser's package.json version
  */
@@ -75,6 +115,7 @@ const build = (buildConfig = config.defaultBuildConfig, options) => {
   checkVersionsMatch()
 
   touchOverriddenFiles()
+  touchOverriddenVectorIconFiles()
 
   if (!options.no_branding_update) {
     util.updateBranding()


### PR DESCRIPTION
We need to touch original icon files to trigger rebuild.

Close https://github.com/brave/brave-browser/issues/491

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
