### PR TITLE
support ui_mode cli flag for start command

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -19,6 +19,9 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   if (options.disable_pdfjs_extension) {
     braveArgs.push('--disable-pdfjs-extension')
   }
+  if (options.ui_mode) {
+    braveArgs.push(`--ui-mode=${options.ui_mode}`)
+  }
   if (!options.enable_brave_update) {
     // This only has meaning with MacOS and official build.
     braveArgs.push('--disable-brave-update')

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -67,6 +67,7 @@ program
   .option('--no_sandbox', 'disable the sandbox')
   .option('--disable_brave_extension', 'disable loading the Brave extension')
   .option('--disable_pdfjs_extension', 'disable loading the PDFJS extension')
+  .option('--ui_mode <ui_mode>', 'which built-in ui appearance mode to use', /^(dark|light)$/i)
   .option('--enable_brave_update', 'enable brave update')
   .option('--channel <target_chanel>', 'target channel to start', /^(beta|dev|nightly|release)$/i, 'release')
   .option('--official_build <official_build>', 'force official build settings')


### PR DESCRIPTION
https://github.com/brave/brave-core/pull/365 introduces a new cli flag `ui-mode={dark,light}`. This supports it from brave-browser.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
