### PR TITLE
WIP: Introduce skip_gn_gen option to build command

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -46,6 +46,7 @@ const Config = function () {
   this.mac_signing_keychain = getNPMConfig(['mac_signing_keychain']) || 'login'
   this.channel = ''
   this.sccache = getNPMConfig(['sccache'])
+  this.skip_gn_gen = false
 }
 
 Config.prototype.buildArgs = function () {
@@ -255,6 +256,9 @@ Config.prototype.update = function (options) {
 
   if (options.gclient_verbose)
     this.gClientVerbose = options.gclient_verbose
+
+  if (options.skip_gn_gen)
+    this.skip_gn_gen = true;
 
   this.projectNames.forEach((projectName) => {
     // don't update refs for projects that have them

--- a/lib/util.js
+++ b/lib/util.js
@@ -186,8 +186,10 @@ const util = {
 
     if (process.platform === 'win32') util.updateOmahaMidlFiles()
 
-    const args = util.buildArgsToString(config.buildArgs())
-    util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], options)
+    if (!config.skip_gn_gen) {
+      const args = util.buildArgsToString(config.buildArgs())
+      util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], options)
+    }
     util.run('ninja', ['-C', config.outputDir, config.buildTarget], options)
   },
 

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -36,6 +36,7 @@ program
   .option('--brave_google_api_key <brave_google_api_key>')
   .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
   .option('--channel <target_chanel>', 'target channel to build', /^(beta|dev|nightly|release)$/i, 'release')
+  .option('--skip_gn_gen', 'Skip gn gen')
   .arguments('[build_config]')
   .action(build)
 


### PR DESCRIPTION
When we don't need to `gn gen`, we can skip it.
This skip will reduce some amount of build time.

Close https://github.com/brave/brave-browser/issues/1081

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
