### PR TITLE
Add CLI arg for starting without Brave Rewards extension

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -19,6 +19,9 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   if (options.disable_brave_extension) {
     braveArgs.push('--disable-brave-extension')
   }
+  if (options.disable_brave_rewards_extension) {
+    braveArgs.push('--disable-brave-rewards-extension')
+  }
   if (options.disable_pdfjs_extension) {
     braveArgs.push('--disable-pdfjs-extension')
   }

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -65,6 +65,7 @@ program
   .option('--user_data_dir_name [base_name]', 'set user data directory base name to [base_name]', 'brave-development')
   .option('--no_sandbox', 'disable the sandbox')
   .option('--disable_brave_extension', 'disable loading the Brave extension')
+  .option('--disable_brave_rewards_extension', 'disable loading the Brave Rewards extension')
   .option('--disable_pdfjs_extension', 'disable loading the PDFJS extension')
   .option('--ui_mode <ui_mode>', 'which built-in ui appearance mode to use', /^(dark|light)$/i)
   .option('--enable_brave_update', 'enable brave update')


### PR DESCRIPTION
    Fixes #1103

    Related: https://github.com/brave/brave-core/pull/431

    You can do this with:

    ```
    npm run start -- --disable_brave_rewards_extension
    ```

    or

    ```
    yarn start --disable_brave_rewards_extension
    ```

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
