### PR TITLE
Introduce --ignore_compile_failure to build script

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -47,6 +47,7 @@ const Config = function () {
   this.channel = ''
   this.sccache = getNPMConfig(['sccache'])
   this.braveReferralsApiKey = getNPMConfig(['brave_referrals_api_key']) || ''
+  this.ignore_compile_failure = false
 }
 
 Config.prototype.buildArgs = function () {
@@ -261,6 +262,9 @@ Config.prototype.update = function (options) {
 
   if (options.gclient_verbose)
     this.gClientVerbose = options.gclient_verbose
+
+  if (options.ignore_compile_failure)
+    this.ignore_compile_failure = true
 
   this.projectNames.forEach((projectName) => {
     // don't update refs for projects that have them

--- a/lib/util.js
+++ b/lib/util.js
@@ -187,9 +187,13 @@ const util = {
 
     if (process.platform === 'win32') util.updateOmahaMidlFiles()
 
+    let num_compile_failure = 1
+    if (config.ignore_compile_failure)
+      num_compile_failure = 1000
+
     const args = util.buildArgsToString(config.buildArgs())
     util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], options)
-    util.run('ninja', ['-C', config.outputDir, config.buildTarget], options)
+    util.run('ninja', ['-C', config.outputDir, config.buildTarget, '-k', num_compile_failure], options)
   },
 
   submoduleSync: (options = {}) => {

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -36,6 +36,7 @@ program
   .option('--brave_google_api_key <brave_google_api_key>')
   .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
   .option('--channel <target_chanel>', 'target channel to build', /^(beta|dev|nightly|release)$/i, 'release')
+  .option('--ignore_compile_failure', 'Keep compiling regardless of error')
   .arguments('[build_config]')
   .action(build)
 


### PR DESCRIPTION
This option compiles files as many as possible regardless of compile error.
It would be useful when we trigger full build before going to bed.

Close https://github.com/brave/brave-browser/issues/1204

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
