### PR TITLE
Add brave_referrals_api_key to build config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -46,6 +46,7 @@ const Config = function () {
   this.mac_signing_keychain = getNPMConfig(['mac_signing_keychain']) || 'login'
   this.channel = ''
   this.sccache = getNPMConfig(['sccache'])
+  this.braveReferralsApiKey = getNPMConfig(['brave_referrals_api_key']) || ''
 }
 
 Config.prototype.buildArgs = function () {
@@ -80,6 +81,7 @@ Config.prototype.buildArgs = function () {
     brave_version_build: version_parts[2],
     chrome_version_string: this.chromeVersion,
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
+    brave_referrals_api_key: this.braveReferralsApiKey,
   }
 
   if (process.platform === 'darwin') {
@@ -223,6 +225,10 @@ Config.prototype.update = function (options) {
 
   if (options.safebrowsing_api_endpoint) {
     this.safeBrowsingApiEndpoint = options.safebrowsing_api_endpoint
+  }
+
+  if (options.brave_referrals_api_key) {
+    this.braveReferralsApiKey = options.brave_referrals_api_key
   }
 
   if (options.debug_build !== null && options.debug_build !== undefined) {


### PR DESCRIPTION
This sets the `brave_referrals_api_key` and is related to the work in brave/brave-core#428

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
