### PR TITLE
WIP: Add check for new `brave_enable_cdm_host_verification` config option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -49,6 +49,8 @@ const Config = function () {
   this.sccache = getNPMConfig(['sccache'])
   this.braveReferralsApiKey = getNPMConfig(['brave_referrals_api_key']) || ''
   this.ignore_compile_failure = false
+  this.enableWidevine = process.platform !== 'linux'
+  this.braveEnableCdmHostVerification = JSON.parse(getNPMConfig(['brave_enable_cdm_host_verification']) || false)
 }
 
 Config.prototype.buildArgs = function () {
@@ -67,7 +69,7 @@ Config.prototype.buildArgs = function () {
     ffmpeg_branding: "Chrome",
     enable_nacl: false,
     // branding_path_component: "brave",
-    enable_widevine: process.platform !== 'linux',
+    enable_widevine: this.enableWidevine,
     target_cpu: this.targetArch,
     is_official_build: this.officialBuild,
     is_debug: this.buildConfig !== 'Release',
@@ -84,6 +86,8 @@ Config.prototype.buildArgs = function () {
     chrome_version_string: this.chromeVersion,
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
     brave_referrals_api_key: this.braveReferralsApiKey,
+    enable_cdm_host_verification: this.braveEnableCdmHostVerification,
+    enable_widevine_cdm_host_verification: this.enableWidevine && this.braveEnableCdmHostVerification
   }
 
   if (process.platform === 'darwin') {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       },
       "brave-core": {
         "dir": "src/brave",
-        "branch": "master",
+        "branch": "readd-widevine-gn-support",
         "repository": {
           "url": "https://github.com/brave/brave-core.git"
         }


### PR DESCRIPTION
If set to `true` via .npmrc, Widevine Host Verification will be enabled for the build
This functionality also requires https://github.com/brave/brave-core/pull/515

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
