### PR TITLE
Add show_component_extensions opt for devs to see component extension…

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -35,6 +35,9 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   if (options.single_process) {
     braveArgs.push('--single-process')
   }
+  if (options.show_component_extensions) {
+    braveArgs.push('--show-component-extension-options')
+  }
 
   let cmdOptions = {
     stdio: 'inherit',

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -68,6 +68,7 @@ program
   .option('--disable_brave_rewards_extension', 'disable loading the Brave Rewards extension')
   .option('--disable_pdfjs_extension', 'disable loading the PDFJS extension')
   .option('--ui_mode <ui_mode>', 'which built-in ui appearance mode to use', /^(dark|light)$/i)
+  .option('--show_component_extensions', 'show component extensions in chrome://extensions')
   .option('--enable_brave_update', 'enable brave update')
   .option('--channel <target_chanel>', 'target channel to start', /^(beta|dev|nightly|release)$/i, 'release')
   .option('--official_build <official_build>', 'force official build settings')


### PR DESCRIPTION
…s in chrome://extensions

Fix https://github.com/brave/brave-browser/issues/1321

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
`npm start -- --show_component_extensions`
Should be able to see component extensions in chrome://extensions.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
