### PR TITLE
Copy brave_privacy_page resource folder for WebRTC policy setting

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -110,8 +110,10 @@ const util = {
     fileMap.add([path.join(braveComponentsDir, 'resources', 'default_100_percent', 'brave'), path.join(chromeComponentsDir, 'resources', 'default_100_percent', 'chromium')])
     fileMap.add([path.join(braveComponentsDir, 'resources', 'default_200_percent', 'brave'), path.join(chromeComponentsDir, 'resources', 'default_200_percent', 'chromium')])
     fileMap.add([path.join(braveAppVectorIconsDir, 'vector_icons', 'brave'), path.join(chromeAppDir, 'vector_icons', 'brave')])
+    // Add brave specific pages.
     fileMap.add([path.join(braveResourcesDir, 'settings', 'brave_page_visibility.js'), path.join(chromeResourcesDir, 'settings', 'brave_page_visibility.js')])
     fileMap.add([path.join(braveResourcesDir, 'settings', 'brave_appearance_page'), path.join(chromeResourcesDir, 'settings', 'brave_appearance_page')])
+    fileMap.add([path.join(braveResourcesDir, 'settings', 'brave_privacy_page'), path.join(chromeResourcesDir, 'settings', 'brave_privacy_page')])
     fileMap.add([path.join(braveResourcesDir, 'settings', 'default_brave_shields_page'), path.join(chromeResourcesDir, 'settings', 'default_brave_shields_page')])
 
     for (const [source, output] of fileMap) {


### PR DESCRIPTION
Requires https://github.com/brave/brave-core/pull/538
Fix https://github.com/brave/brave-browser/issues/551
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
