### PR TITLE
Fix user-data-dir-name switch

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -38,6 +38,17 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   if (options.show_component_extensions) {
     braveArgs.push('--show-component-extension-options')
   }
+  if (options.user_data_dir_name) {
+    let user_data_dir
+    if (process.platform === 'darwin') {
+      user_data_dir = path.join(process.env.HOME, 'Library', 'Application\\ Support', 'BraveSoftware', options.user_data_dir_name)
+    } else if (process.platform === 'win32') {
+      user_data_dir = path.join(process.env.LocalAppData, 'BraveSoftware', options.user_data_dir_name)
+    } else {
+      user_data_dir = path.join(process.env.HOME, '.config', 'BraveSoftware', options.user_data_dir_name)
+    }
+    braveArgs.push('--user-data-dir=' + user_data_dir);
+  }
 
   let cmdOptions = {
     stdio: 'inherit',

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -62,7 +62,7 @@ program
   .command('start')
   .option('--v [log_level]', 'set log level to [log_level]', parseInt, '0')
   .option('--vmodule [modules]', 'verbose log from specific modules')
-  .option('--user_data_dir_name [base_name]', 'set user data directory base name to [base_name]', 'brave-development')
+  .option('--user_data_dir_name [base_name]', 'set user data directory base name to [base_name]', 'Brave-Browser-Development')
   .option('--no_sandbox', 'disable the sandbox')
   .option('--disable_brave_extension', 'disable loading the Brave extension')
   .option('--disable_brave_rewards_extension', 'disable loading the Brave Rewards extension')


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/1445

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
launch Brave by
`npm start -- --user-data-dir-name=TEST`
on three platforms
There should be "TEST" folder in
`~/Library/Application Support/BraveSoftware` on Mac
`%LOCALAPPDATA%\BraveSoftware` on Windows
`~/.config/BraveSoftware` on Linux

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
