### PR TITLE
Do not set default value for --user_data_dir_name 

### DIFF
--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -63,7 +63,7 @@ program
   .command('start')
   .option('--v [log_level]', 'set log level to [log_level]', parseInt, '0')
   .option('--vmodule [modules]', 'verbose log from specific modules')
-  .option('--user_data_dir_name [base_name]', 'set user data directory base name to [base_name]', 'Brave-Browser-Development')
+  .option('--user_data_dir_name [base_name]', 'set user data directory base name to [base_name]')
   .option('--no_sandbox', 'disable the sandbox')
   .option('--disable_brave_extension', 'disable loading the Brave extension')
   .option('--disable_brave_rewards_extension', 'disable loading the Brave Rewards extension')


### PR DESCRIPTION
which means will not apply --user-data-dir switch for plain `npm start`

followup of https://github.com/brave/brave-browser/pull/1446

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
