### PR TITLE
Fix `ninja -k` parameter when ignoring compilation errors

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -182,7 +182,7 @@ const util = {
 
     let num_compile_failure = 1
     if (config.ignore_compile_failure)
-      num_compile_failure = 1000
+      num_compile_failure = 0
 
     const args = util.buildArgsToString(config.buildArgs())
     util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], options)


### PR DESCRIPTION
`ninja -k 0` ignores all errors, as intended when using
`--ignore_compile_failure`.