### PR TITLE
Add options for installer signing key on Mac

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -43,6 +43,7 @@ const Config = function () {
   this.chromeVersion = getNPMConfig(['projects', 'chrome', 'tag']) || '0.0.0.0'
   this.releaseTag = this.braveVersion.split('+')[0]
   this.mac_signing_identifier = getNPMConfig(['mac_signing_identifier']) || ''
+  this.mac_installer_signing_identifier = getNPMConfig(['mac_installer_signing_identifier']) || ''
   this.mac_signing_keychain = getNPMConfig(['mac_signing_keychain']) || 'login'
   this.channel = ''
   this.sccache = getNPMConfig(['sccache'])
@@ -87,6 +88,7 @@ Config.prototype.buildArgs = function () {
 
   if (process.platform === 'darwin') {
     args.mac_signing_identifier = this.mac_signing_identifier
+    args.mac_installer_signing_identifier = this.mac_installer_signing_identifier
     args.mac_signing_keychain = this.mac_signing_keychain
   }
 
@@ -261,6 +263,9 @@ Config.prototype.update = function (options) {
 
   if (options.mac_signing_identifier)
     this.mac_signing_identifier = options.mac_signing_identifier
+
+  if (options.mac_installer_signing_identifier)
+    this.mac_installer_signing_identifier = options.mac_installer_signing_identifier
 
   if (options.mac_signing_keychain)
     this.mac_signing_keychain = options.mac_signing_keychain

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -45,6 +45,7 @@ program
   .option('-C <build_dir>', 'build config (out/Debug, out/Release')
   .option('--target_arch <target_arch>', 'target architecture', 'x64')
   .option('--mac_signing_identifier <id>', 'The identifier to use for signing')
+  .option('--mac_installer_signing_identifier <id>', 'The identifier to use for signing the installer')
   .option('--mac_signing_keychain <keychain>', 'The identifier to use for signing', 'login')
   .option('--debug_build <debug_build>', 'keep debugging symbols')
   .option('--official_build <official_build>', 'force official build settings')


### PR DESCRIPTION
Fixes brave/brave-browser#1412

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
