### PR TITLE
lib/util.js: Add --with_tags flag to gclient sync

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -199,7 +199,7 @@ const util = {
   },
 
   gclientSync: (options = {}) => {
-    runGClient(['sync', '--force', '--nohooks', '--with_branch_heads'], options)
+    runGClient(['sync', '--force', '--nohooks', '--with_branch_heads', '--with_tags'], options)
   },
 
   gclientRunhooks: (options = {}) => {


### PR DESCRIPTION
This commit adds the --with_tags flag to gclient sync in the hopes that
doing so will fix the error while building whereby some builds will fail
due to tags not existing in some repository clones.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
