### PR TITLE
always reset DEPS without rebasing when running `init`

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -198,8 +198,11 @@ const util = {
     util.run('git', ['-C', config.depotToolsDir, 'reset', '--hard', 'HEAD'], options)
   },
 
-  gclientSync: (options = {}) => {
-    runGClient(['sync', '--force', '--nohooks', '--with_branch_heads', '--with_tags'], options)
+  gclientSync: (reset = false, options = {}) => {
+    let args = ['sync', '--force', '--nohooks', '--with_branch_heads', '--with_tags']
+    if (reset)
+      args.push('--upstream')
+    runGClient(args, options)
   },
 
   gclientRunhooks: (options = {}) => {

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -32,7 +32,7 @@ if (program.init) {
 }
 
 if (program.init) {
-  util.gclientSync()
+  util.gclientSync(true)
 }
 
 let updatedVersion = false


### PR DESCRIPTION
At some point in the past depot tools behavior changed to automatically rebase local changes. That may actually be desirable when running `npm run sync`, but `npm run init` is expected to reset everything to a pristine state.