### PR TITLE
WIP: Add build_omaha sub command to create_dist command

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -56,6 +56,8 @@ Config.prototype.buildArgs = function () {
   let version_parts = version.split('+')[0]
   version_parts = version_parts.split('.')
 
+  const chrome_version_parts = this.chromeVersion.split('.')
+
   let args = {
     safe_browsing_mode: 1,
     root_extra_deps: [ "//brave" ],
@@ -82,6 +84,7 @@ Config.prototype.buildArgs = function () {
     brave_version_minor: version_parts[1],
     brave_version_build: version_parts[2],
     chrome_version_string: this.chromeVersion,
+    chrome_version_major: chrome_version_parts[0],
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
     brave_referrals_api_key: this.braveReferralsApiKey,
   }
@@ -90,6 +93,10 @@ Config.prototype.buildArgs = function () {
     args.mac_signing_identifier = this.mac_signing_identifier
     args.mac_installer_signing_identifier = this.mac_installer_signing_identifier
     args.mac_signing_keychain = this.mac_signing_keychain
+  }
+
+  if (process.platform === 'win32') {
+    args.build_omaha = this.build_omaha
   }
 
   if (this.debugBuild) {
@@ -259,6 +266,10 @@ Config.prototype.update = function (options) {
   } else if (options.channel !== 'release') {
     // In chromium src, empty string represents stable channel.
     this.channel = options.channel
+  }
+
+  if (process.platform === 'win32' && options.build_omaha) {
+    this.build_omaha = true
   }
 
   if (options.mac_signing_identifier)

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -52,6 +52,7 @@ program
   .option('--brave_google_api_key <brave_google_api_key>')
   .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
   .option('--channel <target_chanel>', 'target channel to build', /^(beta|dev|nightly|release)$/i, 'release')
+  .option('--build_omaha', 'build omaha stub/standalone installer')
   .arguments('[build_config]')
   .action(createDist)
 


### PR DESCRIPTION
Build omaha stub/standalone installer when --build_omaha option is
passed to create_dist command.

Close https://github.com/brave/brave-browser/issues/1784

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
