### PR TITLE
npm audit command should check vendor directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.58.1",
   "description": "Next generation Brave browser for macOS, Windows, Linux, and eventually Android",
   "scripts": {
+    "audit_deps": "node ./scripts/audit.js",
     "cibuild": "node ./scripts/commands.js cibuild",
     "init": "node ./scripts/sync.js --init",
     "create_dist": "node ./scripts/commands.js create_dist",
@@ -18,7 +19,7 @@
     "pull_l10n": "node ./scripts/commands.js pull_l10n",
     "chromium_rebase_l10n": "node ./scripts/commands.js chromium_rebase_l10n",
     "test": "node ./scripts/commands.js test",
-    "test-security": "npm audit && node ./scripts/commands.js start --enable_brave_update --network_log --user_data_dir_name=brave-network-test"
+    "test-security": "npm run audit_deps && node ./scripts/commands.js start --enable_brave_update --network_log --user_data_dir_name=brave-network-test"
   },
   "config": {
     "projects": {

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const path = require('path')
+const fs = require('fs')
+const util = require('../lib/util')
+
+const baseDir = path.resolve(path.join(__dirname, '..'))
+const braveDir = path.join(baseDir, 'src', 'brave')
+const braveVendorDir = path.join(braveDir, 'vendor')
+
+/**
+ * Runs npm audit on a given directory located at pathname
+ */
+function npmAudit (pathname) {
+  if (fs.existsSync(path.join(pathname, 'package.json')) &&
+    fs.existsSync(path.join(pathname, 'package-lock.json'))) {
+    console.log('Auditing', pathname)
+    util.run('npm', ['audit'], { cwd: pathname })
+  } else {
+    console.log('Skipping audit of', pathname)
+  }
+}
+
+npmAudit(baseDir)
+npmAudit(braveDir)
+fs.readdirSync(braveVendorDir).forEach((dir) => {
+  npmAudit(path.join(braveVendorDir, dir))
+})


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/1853

note that this audit will fail until all the PRs i opened in the vendor
directories are merged. see
https://github.com/brave/brave-browser/issues/1853 for references to
those PRs.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
