### PR TITLE
Replace chrome branding on win8 welcome page with brave one

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -81,6 +81,8 @@ const util = {
     const braveComponentsDir = path.join(config.projects['brave-core'].dir, 'components')
     const chromeAppDir = path.join(config.srcDir, 'chrome', 'app')
     const braveAppDir = path.join(config.projects['brave-core'].dir, 'app')
+    const chromeBrowserResourcesDir = path.join(config.srcDir, 'chrome', 'browser', 'resources')
+    const braveBrowserResourcesDir = path.join(config.projects['brave-core'].dir, 'browser', 'resources')
     const braveAppVectorIconsDir = path.join(config.projects['brave-core'].dir, 'vector_icons', 'chrome', 'app')
 
     let fileMap = new Set();
@@ -106,6 +108,8 @@ const util = {
     fileMap.add([path.join(braveComponentsDir, 'resources', 'default_100_percent', 'brave'), path.join(chromeComponentsDir, 'resources', 'default_100_percent', 'chromium')])
     fileMap.add([path.join(braveComponentsDir, 'resources', 'default_200_percent', 'brave'), path.join(chromeComponentsDir, 'resources', 'default_200_percent', 'chromium')])
     fileMap.add([path.join(braveAppVectorIconsDir, 'vector_icons', 'brave'), path.join(chromeAppDir, 'vector_icons', 'brave')])
+    // Copy chrome-logo-faded.png for replacing chrome logo of welcome page with brave's on Win8.
+    fileMap.add([path.join(braveBrowserResourcesDir, 'chrome-logo-faded.png'), path.join(chromeBrowserResourcesDir, 'chrome-logo-faded.png')])
 
     for (const [source, output] of fileMap) {
       let sourceFiles = []


### PR DESCRIPTION
Close https://github.com/brave/brave-browser/issues/1335

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
Newly install on win8

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
