### PR TITLE
Add disable_webtorrent_extension option

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -29,6 +29,9 @@ const start = (buildConfig = config.defaultBuildConfig, options) => {
   if (options.disable_pdfjs_extension) {
     braveArgs.push('--disable-pdfjs-extension')
   }
+  if (options.disable_webtorrent_extension) {
+    braveArgs.push('--disable-webtorrent-extension')
+  }
   if (options.ui_mode) {
     braveArgs.push(`--ui-mode=${options.ui_mode}`)
   }

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -71,6 +71,7 @@ program
   .option('--disable_brave_extension', 'disable loading the Brave extension')
   .option('--disable_brave_rewards_extension', 'disable loading the Brave Rewards extension')
   .option('--disable_pdfjs_extension', 'disable loading the PDFJS extension')
+  .option('--disable_webtorrent_extension', 'disable loading the WebTorrent extension')
   .option('--ui_mode <ui_mode>', 'which built-in ui appearance mode to use', /^(dark|light)$/i)
   .option('--show_component_extensions', 'show component extensions in chrome://extensions')
   .option('--enable_brave_update', 'enable brave update')


### PR DESCRIPTION
Add disable_webtorrent_extension option so developers could easily disable webtorrent extension while `npm start`.

Part of https://github.com/brave/brave-browser/issues/2043
See also https://github.com/brave/brave-core/pull/832 for brave-core PR.
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
