### PR TITLE
docs/installing-brave.rst: add brave-keyring package entry

### DIFF
--- a/docs/source/installing-brave.rst
+++ b/docs/source/installing-brave.rst
@@ -19,7 +19,7 @@ Ubuntu 16.04+
 
     sudo apt update
 
-    sudo apt install brave-browser
+    sudo apt install brave-browser brave-keyring
 
 
 Mint 17+
@@ -34,7 +34,7 @@ Mint 17+
 
     sudo apt update
 
-    sudo apt install brave-browser
+    sudo apt install brave-browser brave-keyring
 
 
 Fedora 28+
@@ -45,7 +45,7 @@ Fedora 28+
 
     sudo rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
 
-    sudo dnf install brave-browser
+    sudo dnf install brave-browser brave-keyring
 
 
 Centos/RHel
@@ -61,7 +61,7 @@ Centos/RHel
     enabled=1
     EOF
 
-    sudo yum install brave-browser
+    sudo yum install brave-browser brave-keyring
 
 
 Beta Channel Installation


### PR DESCRIPTION
This commit adds the brave-keyring package entry to the instructions for
installing the release version of brave-browser

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [X] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [X] Ran `git rebase master` (if needed).
- [X] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
