### PR TITLE
Resolves #1981: silence curl download progress in piped command to add key

### DIFF
--- a/docs/source/installing-brave.rst
+++ b/docs/source/installing-brave.rst
@@ -13,7 +13,7 @@ Ubuntu 16.04+
 -------------
 ::
 
-    curl https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key add -
+    curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key add -
 
     echo "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ `lsb_release -sc` main" | sudo tee -a /etc/apt/sources.list.d/brave-browser-release-`lsb_release -sc`.list
 
@@ -26,7 +26,7 @@ Mint 17+
 --------
 ::
 
-    curl https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key add -
+    curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key add -
 
     UBUNTU_CODENAME=$( (grep DISTRIB_CODENAME /etc/upstream-release/lsb-release || grep DISTRIB_CODENAME /etc/lsb-release) 2>/dev/null | cut -d'=' -f2 )
 
@@ -73,7 +73,7 @@ Ubuntu 16.04+
 -------------
 ::
 
-    curl https://brave-browser-apt-beta.s3.brave.com/brave-core-nightly.asc | sudo apt-key add -
+    curl -s https://brave-browser-apt-beta.s3.brave.com/brave-core-nightly.asc | sudo apt-key add -
 
     echo "deb [arch=amd64] https://brave-browser-apt-beta.s3.brave.com/ `lsb_release -sc` main" | sudo tee -a /etc/apt/sources.list.d/brave-browser-beta-`lsb_release -sc`.list
 
@@ -86,7 +86,7 @@ Mint 17+
 --------
 ::
 
-    curl https://brave-browser-apt-beta.s3.brave.com/brave-core-nightly.asc | sudo apt-key add -
+    curl -s https://brave-browser-apt-beta.s3.brave.com/brave-core-nightly.asc | sudo apt-key add -
 
     UBUNTU_CODENAME=$( (grep DISTRIB_CODENAME /etc/upstream-release/lsb-release || grep DISTRIB_CODENAME /etc/lsb-release) 2>/dev/null | cut -d'=' -f2 )
 
@@ -132,7 +132,7 @@ Ubuntu 16.04+
 -------------
 ::
 
-    curl https://brave-browser-apt-dev.s3.brave.com/brave-core-nightly.asc | sudo apt-key add -
+    curl -s https://brave-browser-apt-dev.s3.brave.com/brave-core-nightly.asc | sudo apt-key add -
 
     echo "deb [arch=amd64] https://brave-browser-apt-dev.s3.brave.com/ `lsb_release -sc` main" | sudo tee -a /etc/apt/sources.list.d/brave-browser-dev-`lsb_release -sc`.list
 
@@ -147,7 +147,7 @@ Mint 17+
 --------
 ::
 
-    curl https://brave-browser-apt-dev.s3.brave.com/brave-core-nightly.asc | sudo apt-key add -
+    curl -s https://brave-browser-apt-dev.s3.brave.com/brave-core-nightly.asc | sudo apt-key add -
 
     UBUNTU_CODENAME=$( (grep DISTRIB_CODENAME /etc/upstream-release/lsb-release || grep DISTRIB_CODENAME /etc/lsb-release) 2>/dev/null | cut -d'=' -f2 )
 


### PR DESCRIPTION
Simple edit to linux installation guide.
When curl is called without the -s flag it stalls on the download progress and does not add key.

## Submitter Checklist:

- [x] This fix could help with related [ticket #1981](https://github.com/brave/brave-browser/issues/1981) concerning people having problems installing Brave
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
