### PR TITLE
add network audit whitelist entries for crlset PR

### DIFF
--- a/lib/whitelistedUrlPrefixes.js
+++ b/lib/whitelistedUrlPrefixes.js
@@ -1,7 +1,13 @@
 // Before adding to this list, get approval from the security team
 module.exports = [
+  'http://update.googleapis.com/service/update2', // allowed because it 307's to go-updater.brave.com. should never actually connect to googleapis.com.
   'https://update.googleapis.com/service/update2', // allowed because it 307's to go-updater.brave.com. should never actually connect to googleapis.com.
   'https://safebrowsing.googleapis.com/v4/threatListUpdates', // allowed because it 307's to safebrowsing.brave.com
+  'http://redirector.gvt1.com/edgedl/release2/chrome_component/', // allowed because it 307's to crlset2.brave.com
+  'https://redirector.gvt1.com/edgedl/release2/chrome_component/', // allowed because it 307's to crlset2.brave.com
+  'https://clients2.googleusercontent.com/crx/blobs/',
+  'http://dl.google.com/release2/chrome_component/', // allowed because it 307's to crlset1.brave.com
+  'https://dl.google.com/release2/chrome_component/', // allowed because it 307's to crlset1.brave.com
   'https://no-thanks.invalid/', // fake gaia URL
   'https://go-updater.brave.com/',
   'https://safebrowsing.brave.com/',
@@ -9,6 +15,11 @@ module.exports = [
   'https://laptop-updates.brave.com/',
   'https://static.brave.com/',
   'https://static1.brave.com/',
+  'http://componentupdater.brave.com/service/update2', // allowed because it 307's to https://componentupdater.brave.com
+  'https://componentupdater.brave.com/service/update2',
+  'https://crlsets2.brave.com/',
+  'https://crlsets1.brave.com/',
+  'https://crxdownload.brave.com/crx/blobs/',
   'https://ledger.mercury.basicattentiontoken.org/',
   'https://ledger-staging.mercury.basicattentiontoken.org/',
   'https://balance.mercury.basicattentiontoken.org/',


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2271

test step: `npm run network-audit` should pass

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
