### PR TITLE
Use two issue templates, one for issues and one for fature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,18 +1,22 @@
-<!-- Have you searched for similar issues? Before submitting this issue, please check the open issues and add a note before logging a new issue. 
+---
+name: Bug report
+about: Let us know about an unexpected error, a crash, or an incorrect behavior.
+---
+<!-- Have you searched for similar issues? Before submitting this issue, please check the open issues and add a note before logging a new issue.
 
-PLEASE USE THE TEMPLATE BELOW TO PROVIDE INFORMATION ABOUT THE ISSUE. 
+PLEASE USE THE TEMPLATE BELOW TO PROVIDE INFORMATION ABOUT THE ISSUE.
 INSUFFICIENT INFO WILL GET THE ISSUE CLOSED. IT WILL ONLY BE REOPENED AFTER SUFFICIENT INFO IS PROVIDED-->
 
-## Description 
+## Description
 <!--Provide a brief description of the issue-->
 
 
 ## Steps to Reproduce
 <!--Please add a series of steps to reproduce the issue-->
 
-   1. 
-   2. 
-   3. 
+   1.
+   2.
+   3.
 
 ## Actual result:
 <!--Please add screenshots if needed-->
@@ -21,7 +25,7 @@ INSUFFICIENT INFO WILL GET THE ISSUE CLOSED. IT WILL ONLY BE REOPENED AFTER SUFF
 ## Expected result:
 
 
-## Reproduces how often: 
+## Reproduces how often:
 <!--[Easily reproduced/Intermittent issue/No steps to reproduce]-->
 
 
@@ -30,11 +34,11 @@ INSUFFICIENT INFO WILL GET THE ISSUE CLOSED. IT WILL ONLY BE REOPENED AFTER SUFF
 
 
 ### Reproducible on current release:
-- Does it reproduce on brave-browser dev/beta builds? 
+- Does it reproduce on brave-browser dev/beta builds?
 
 ### Website problems only:  
-- Does the issue resolve itself when disabling Brave Shields? 
-- Is the issue reproducible on the latest version of Chrome? 
+- Does the issue resolve itself when disabling Brave Shields?
+- Is the issue reproducible on the latest version of Chrome?
 
 ### Additional Information
 <!--Any additional information, related issues, extra QA steps, configuration or data that might be necessary to reproduce the issue-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or other enhancement.
+---
+
+### Current Brave version
+<!--For installed build, please copy Brave, Revision and OS from brave://version and paste here. If building from source please mention it along with brave://version details-->
+
+
+### Use-cases
+<!-- In order to properly evaluate a feature request, it is necessary to understand the use-cases for it. Please describe below the end goal you are trying to achieve that has led you to request this feature. -->
+
+
+### Proposal
+<!-- If you have any idea on how it could be addressed, please note it below: -->
+
+
+### References
+<!-- Are there any other GitHub issues, whether open or closed, that are related to the problem you've described above or to the suggested solution? If so, please add them bellow: -->


### PR DESCRIPTION
Fixes #2435

## Test plan:

Go to https://github.com/Jacalz/brave-browser/issues

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Tagged reviewers and labelled the pull request as needed.
