### PR TITLE
Add skip_signing option to create_dist target

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -100,6 +100,10 @@ Config.prototype.buildArgs = function () {
     args.tag_ap = this.tag_ap
   }
 
+  if (this.skip_signing) {
+    args.skip_signing = true
+  }
+
   if (this.debugBuild) {
     if (process.platform === 'darwin') {
       args.enable_stripping = false
@@ -272,6 +276,10 @@ Config.prototype.update = function (options) {
   if (process.platform === 'win32' && options.build_omaha) {
     this.build_omaha = true
     this.tag_ap = options.tag_ap
+  }
+
+  if (options.skip_signing) {
+    this.skip_signing = true
   }
 
   if (options.mac_signing_identifier)

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -54,6 +54,7 @@ program
   .option('--channel <target_chanel>', 'target channel to build', /^(beta|dev|nightly|release)$/i, 'release')
   .option('--build_omaha', 'build omaha stub/standalone installer')
   .option('--tag_ap <ap>', 'ap for stub/standalone installer')
+  .option('--skip_signing', 'skip signing dmg')
   .arguments('[build_config]')
   .action(createDist)
 


### PR DESCRIPTION
When --skip_signing is used for create_dist, unsigned dmg is created
in src/out/Release/unsigned_dmg.

Fix https://github.com/brave/brave-browser/issues/2460

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
1. Run `yarn create_dist Release --skip_signing`
2. Check dmg is created in `src/out/Release/unsigned_dmg`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
