### PR TITLE
Upgrade from Chromium 71.0.3578.80 to 71.0.3578.98

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "71.0.3578.80",
+        "tag": "71.0.3578.98",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2556

Looks like only PDFium security fix was addressed which we don't include anyway. But for fingerprinting reasons and perception we want to stay up to the date with latest version.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
