### PR TITLE
Replace "Chrome Web Store" with "Web Store" in 0.58.x

### DIFF
--- a/lib/l10nUtil.js
+++ b/lib/l10nUtil.js
@@ -126,6 +126,7 @@ module.exports.rebaseBraveStringFilesOnChromiumL10nFiles = async function (path)
 const defaultReplacements = [
   [/Automatically send usage statistics and crash reports to Google/g, 'Automatically send crash reports to Google'],
   [/Automatically sends usage statistics and crash reports to Google/g, 'Automatically sends crash reports to Google'],
+  [/Chrome Web Store/g, 'Web Store'],
   [/The Chromium Authors/g, 'Brave Software Inc'],
   [/Google Chrome/g, 'Brave'],
   [/Chromium/g, 'Brave'],


### PR DESCRIPTION
Adds an entry to replace 'Chrome Web Store' with just 'Web Store' in l10Util.js.

Fixes brave/brave-browser#2625
in conjunction with brave/brave-core#1133

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
See brave/brave-core#1133

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
