### PR TITLE
Issue 2786: JSON parsing error while running test security

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -87,7 +87,7 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
     stdio: 'inherit',
     timeout: options.network_log ? 120000 : undefined,
     continueOnFail: options.network_log ? true : false,
-    shell: true
+    shell: process.platform === 'linux' && options.network_log ? false : true
   }
 
   if (options.network_log) {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/2786

On linux, with shell set to true `spawnSync timeout` fails to kill the running browser window causing JSON parsing error since network_log is being written.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
