### PR TITLE
Enable hangouts extension to allow screen share

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -49,6 +49,8 @@ const Config = function () {
   this.sccache = getNPMConfig(['sccache'])
   this.braveReferralsApiKey = getNPMConfig(['brave_referrals_api_key']) || ''
   this.ignore_compile_failure = false
+  this.enable_hangout_services_extension = true
+
 }
 
 Config.prototype.buildArgs = function () {
@@ -87,6 +89,7 @@ Config.prototype.buildArgs = function () {
     chrome_version_major: chrome_version_parts[0],
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
     brave_referrals_api_key: this.braveReferralsApiKey,
+    enable_hangout_services_extension: this.enable_hangout_services_extension
   }
 
   if (process.platform === 'darwin') {


### PR DESCRIPTION
Uplift request for: https://github.com/brave/brave-browser/pull/1983
Fix https://github.com/brave/brave-browser/issues/1982
Requires: https://github.com/brave/brave-core/pull/1250