### PR TITLE
Add GN flag to disable building cloud print and disable pdfium on non-windows

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -91,7 +91,8 @@ Config.prototype.buildArgs = function () {
     chrome_version_major: chrome_version_parts[0],
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
     brave_referrals_api_key: this.braveReferralsApiKey,
-    enable_hangout_services_extension: this.enable_hangout_services_extension
+    enable_hangout_services_extension: this.enable_hangout_services_extension,
+    enable_pdf: process.platform === 'win32',  // disable pdfium on non-windows
   }
 
   if (process.platform === 'darwin') {


### PR DESCRIPTION
This partially addresses #1958 except on Windows.
cc: @fmarier 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
