### PR TITLE
Issue 3025: Add a buildflag/runtime switch to disable STP by default

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -40,6 +40,9 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
     // This only has meaning with MacOS and official build.
     braveArgs.push('--disable-brave-update')
   }
+  if (options.enable_smart_tracking_protection) {
+    braveArgs.push('--enable-smart-tracking-protection')
+  }
   if (options.single_process) {
     braveArgs.push('--single-process')
   }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/3025

### Description
STP can cause webcompat issues, so gating this feature behind off-by-default runtime flag till the feature is thoroughly tested.

More details about the feature/switches is available here:
https://github.com/brave/brave-core/pull/403

auditors: @bridiver, @bsclifton

Please reach out if you have any questions.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:

The test plan for this change is covered in: https://github.com/brave/brave-core/pull/403 (For Devs - Enable STP runtime and buildflags)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
