### PR TITLE
update_patches command becomes async

### DIFF
--- a/lib/updatePatches.js
+++ b/lib/updatePatches.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra')
 const config = require('../lib/config')
 const util = require('../lib/util')
 
-const updatePatches = (options) => {
+const updatePatches = async (options) => {
   config.update(options)
 
   const patchDir = path.join(config.projects['brave-core'].dir, 'patches')
@@ -18,8 +18,7 @@ const updatePatches = (options) => {
 
   // grab Modified (and later Deleted) files but not Created (since we copy those)
   const modifiedDiffArgs = ['diff', '--diff-filter=M', '--name-only', '--ignore-space-at-eol']
-  const modifiedDiff = util.run('git', modifiedDiffArgs, runOptionsChrome)
-  const modifiedFileList = modifiedDiff.stdout.toString()
+  const modifiedFileList = (await util.runAsync('git', modifiedDiffArgs, runOptionsChrome))
     .split('\n')
     .filter(s => s.length > 0 &&
             !s.startsWith('chrome/app/theme/default') &&
@@ -38,8 +37,8 @@ const updatePatches = (options) => {
 
   // grab every existing patch file in the dir (at this point, patchfiles for now-unmodified files live on)
   const existingFileArgs = ['ls-files', '--exclude-standard']
-  let existingFileOutput = util.run('git', existingFileArgs, runOptionsPatch)
-  let existingFileList = existingFileOutput.stdout.toString().split('\n').filter(s => s.length > 0)
+  let existingFileList = (await util.runAsync('git', existingFileArgs, runOptionsPatch))
+                          .split('\n').filter(s => s.length > 0)
 
   // Add files here we specifically want to keep around regardless
   const exclusionList = []
@@ -61,22 +60,20 @@ const updatePatches = (options) => {
   // appear, you can quickly patch this by changing the separator, even
   // to something longer
 
-  let n = modifiedFileList.length
-
-  for (let i = 0; i < n; i++) {
-    const old = modifiedFileList[i]
-    const revised = substitutedFileList[i]
-
+  let writeOpsDoneCount = 0
+  let writePatchOps = modifiedFileList.map(async (old, i) => {
     const singleDiffArgs = ['diff', '--src-prefix=a/', '--dst-prefix=b/', '--full-index', old]
-    let singleDiff = util.run('git', singleDiffArgs, runOptionsChrome)
+    const patchContents = await util.runAsync('git', singleDiffArgs, runOptionsChrome)
+    const patchFilename = substitutedFileList[i]
+    await fs.writeFile(path.join(patchDir, patchFilename), patchContents)
 
-    const contents = singleDiff.stdout.toString()
-    const filename = revised
+    writeOpsDoneCount++
+    console.log(
+      `updatePatches wrote ${writeOpsDoneCount} / ${modifiedFileList.length}: ${patchFilename}`
+    )
+  })
 
-    fs.writeFileSync(path.join(patchDir, filename), contents)
-
-    console.log('updatePatches wrote ' + (1 + i) + '/' + n + ': ' + filename)
-  }
+  await Promise.all(writePatchOps)
 
   // regular rm patchfiles whose target is no longer modified
   let m = cruftList.length

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const spawnSync = require('child_process').spawnSync
+const { spawn, spawnSync } = require('child_process')
 const config = require('./config')
 const fs = require('fs-extra')
 const crypto = require('crypto')
@@ -32,6 +32,32 @@ const util = {
       }
     }
     return prog
+  },
+
+  runAsync: (cmd, args = [], options = {}) => {
+    console.log(cmd, args.join(' '))
+    const continueOnFail = options.continueOnFail
+    delete options.continueOnFail
+    return new Promise((resolve, reject) => {
+      const prog = spawn(cmd, args, options)
+      let stderr = ''
+      let stdout = ''
+      prog.stderr.on('data', data => {
+        stderr += data
+      })
+      prog.stdout.on('data', data => {
+        stdout += data
+      })
+      prog.on('close', statusCode => {
+        const hasFailed = statusCode !== 0
+        if (hasFailed && !continueOnFail) {
+          console.log(stdout)
+          console.error(stderr)
+          process.exit(1)
+        }
+        resolve(stdout)
+      })
+    })
   },
 
   buildGClientConfig: () => {


### PR DESCRIPTION
Runs each patch diff and writing in parallel.

A small update that reduces time on my two machines:
From ~45s to ~20s 
From ~35s to ~10s

Given we now have over 300 patches, it seems about the right time to put this in.

Git diff is safe to run in parallel.

Fix https://github.com/brave/brave-browser/issues/3084

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
`npm run update_patches`
Verify that no changes are made in `src/brave/patches`
Modify a chromium file
`npm run update_patches`
Verify that the single change is visible in `src/brave/patches`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
