### PR TITLE
Command to modify only chromium source files whose patches have changed

### DIFF
--- a/lib/applyPatchesDelta.js
+++ b/lib/applyPatchesDelta.js
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+
+const { EOL } = require('os')
+const { runAsync } = require('./util')
+const path = require('path')
+const fs = require('fs-extra')
+const config = require('../lib/config')
+
+const findPatchFileRegex = /^([ADM])\tpatches\/(.*).patch/
+
+module.exports = async function (refRange, options) {
+  config.update(options)
+
+  if (!refRange) {
+    console.error('ref_range argument is required!')
+    process.exit(1)
+  }
+  
+  const braveDir = config.projects['brave-core'].dir
+  const patchDir = path.join(braveDir, 'patches')
+  const runOptionsBrave = { cwd: braveDir }
+  const runOptionsChrome = { cwd: config.projects.chrome.dir }
+  const runOptionsPatch = { cwd: patchDir }
+
+  // get changed patch files
+  console.log(`Finding changed patch files in range: ${refRange}`)
+  const allChangedFilenames = (await runAsync('git', ['diff', '--name-status', refRange], runOptionsBrave)).split(EOL)
+  const patchFileMatches = allChangedFilenames.map(line => findPatchFileRegex.exec(line)).filter(line => line && line.length === 3)
+  if (!patchFileMatches.length) {
+    console.log('No patch file changes found :-)')
+    if (!allChangedFilenames.length) {
+      console.log('...no file changes at all in this range! :-o')
+    } else {
+      console.log('Other file changes:')
+      for (const fileChange of allChangedFilenames) {
+        console.log(fileChange)
+      }
+    }
+    // still a happy case
+    process.exit(0)
+  }
+  for (const match of patchFileMatches) {
+    // 	patches/ui-webui-resources-css-md_colors.css.patch
+    console.log(`Processing: ${match[1]} - ${match[2]}`)
+    const actionCode = match[1]
+    if (!['A', 'D', 'M'].includes(actionCode)) {
+      console.error(`Unknown git action code: ${actionCode} in line: ${match[0]}`)
+      console.error('This script only knows how to handle patch files which are added, removed or modified.')
+      process.exit(1)
+    }
+    const srcPath = match[2].replace(/-/g, '/')
+    const patchPath = `brave/patches/${match[2]}.patch`
+
+    // reset
+    console.log(`Resetting: ${srcPath}`)
+    await runAsync('git', ['checkout', '--', srcPath], runOptionsChrome)
+
+    if (actionCode === 'D') {
+      // patch was deleted, do nothing else
+      continue
+    }
+
+    // patch was added or modified, re-apply
+    console.log(`Applying patch: ${patchPath}`)
+    await runAsync('git', ['apply', patchPath], runOptionsChrome)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "upload": "node ./scripts/commands.js upload",
     "update_patches": "node ./scripts/commands.js update_patches",
     "apply_patches": "node ./scripts/sync.js --run_hooks",
+    "apply_patches_delta": "node ./scripts/commands.js apply_patches_delta",
     "start": "node ./scripts/commands.js start",
     "network-audit": "node ./scripts/commands.js start --enable_brave_update --network_log --user_data_dir_name=brave-network-test",
     "push_l10n": "node ./scripts/commands.js push_l10n",

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -17,6 +17,7 @@ const chromiumRebaseL10n = require('../lib/chromiumRebaseL10n')
 const createDist = require('../lib/createDist')
 const upload = require('../lib/upload')
 const test = require('../lib/test')
+const applyPatchesDelta = require('../lib/applyPatchesDelta')
 
 const parsedArgs = program.parseOptions(process.argv)
 
@@ -110,6 +111,11 @@ program
 program
   .command('update_patches')
   .action(updatePatches)
+
+program
+  .command('apply_patches_delta')
+  .arguments('[ref_range]')
+  .action(applyPatchesDelta)
 
 program
   .command('cibuild')


### PR DESCRIPTION
Allows to touch / modify only the chromium source files which have changed between different checkout states.

Fix https://github.com/brave/brave-browser/issues/3184

Since this is only likely useful when the developer knows there is no other need for a full sync, it's a separate command.

Example usage when going back to master from a feature branch:

```
* on branch 'my-feature'
brave-browser/src/brave > git checkout master
brave-browser/src/brave > git pull
brave-browser > npm run apply_patches_delta -- my-feature..master

Finding changed patch files in range: my-feature..master
git diff --name-status my-feature..master
Processing: A - chrome-app-chrome_crash_reporter_client.cc
Resetting: chrome/app/chrome_crash_reporter_client.cc
git checkout -- chrome/app/chrome_crash_reporter_client.cc
Applying patch: brave/patches/chrome-app-chrome_crash_reporter_client.cc.patch
git apply brave/patches/chrome-app-chrome_crash_reporter_client.cc.patch
Processing: M - chrome-app-chrome_crash_reporter_other.cc
Resetting: chrome/app/chrome_crash_reporter_other.cc
git checkout -- chrome/app/chrome_crash_reporter_other.cc
Applying patch: brave/patches/chrome-app-chrome_crash_reporter_client.cc.patch
git apply brave/patches/chrome-app-chrome_crash_reporter_client.cc.patch
Processing: D - components-crash-content-app-breakpad_linux.cc
Resetting: components/crash/content/app/breakpad_linux.cc
git checkout -- components/crash/content/app/breakpad_linux.cc
```
