### PR TITLE
Add Debian install instructions

### DIFF
--- a/docs/source/installing-brave.rst
+++ b/docs/source/installing-brave.rst
@@ -15,6 +15,21 @@ Release Channel Installation
 
 .. highlight:: console
 
+Debian
+--------------------------
+::
+
+    curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key --keyring /etc/apt/trusted.gpg.d/brave-browser-release.gpg add -
+
+    source /etc/os-release && CODENAME=$(echo $VERSION | rev | cut -c 2- | rev | cut -d"(" -f 2)
+
+    echo "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ $CODENAME main" | sudo tee /etc/apt/sources.list.d/brave-browser.list
+
+    sudo apt update
+
+    sudo apt install brave-browser brave-keyring
+
+
 Ubuntu 16.04+ and Mint 18+
 --------------------------
 ::


### PR DESCRIPTION
People keep tripping over the UBUNTU_CODENAME stuff when installing in Debian, so I wrote s separate section for Debian.

When reviewing, I'd love for someone Debianier than I am to confirm that my text-manipulation to extract the Debian version name from the fields in `/etc/os-release` is (1) legit & (2) not unnecessarily fragile. Either way, hopefully we can just change the default instructions to use the keyword "stable" before the next major Debian release.