### PR TITLE
Support widevine linux with bundle w/o default shipping

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -52,7 +52,7 @@ const Config = function () {
   this.braveReferralsApiKey = getNPMConfig(['brave_referrals_api_key']) || ''
   this.ignore_compile_failure = false
   this.enable_hangout_services_extension = true
-
+  this.widevineVersion = getNPMConfig(['widevine', 'version'])
 }
 
 Config.prototype.buildArgs = function () {
@@ -73,7 +73,7 @@ Config.prototype.buildArgs = function () {
     ffmpeg_branding: "Chrome",
     enable_nacl: false,
     // branding_path_component: "brave",
-    enable_widevine: process.platform !== 'linux',
+    enable_widevine: true,
     target_cpu: this.targetArch,
     is_official_build: this.officialBuild,
     is_debug: this.buildConfig !== 'Release',

--- a/lib/util.js
+++ b/lib/util.js
@@ -208,6 +208,56 @@ const util = {
     fs.copySync(srcDir, dstDir)
   },
 
+  // To build w/o much modification of upstream file, bundling mode is used. To build with this mode,
+  // widevine header file and cdm lib is needed. So, we use fake cdm lib. It only used by gn checking.
+  // Real cdm lib is only donwloaded and installed when user accepts via content settings bubble
+  // because we don't ship cdm lib by default.
+  // Latest version and download url are inserted to cdm header file and brave-core refers it.
+  prepareWidevineCdmBuild: () => {
+    const widevineDir = path.join(config.srcDir, 'third_party', 'widevine', 'cdm', 'linux', 'x64')
+    fs.ensureDirSync(widevineDir)
+
+    const widevineConfig = {
+      widevineDir,
+      headerFileContent: '',
+      configuredVersion: config.widevineVersion,
+      widevineCdmHeaderFilePath: path.join(widevineDir, 'widevine_cdm_version.h'),
+      fakeWidevineCdmLibFilePath: path.join(widevineDir, 'libwidevinecdm.so')
+    }
+
+    widevineConfig.headerFileContent =
+`#ifndef WIDEVINE_CDM_VERSION_H_
+#define WIDEVINE_CDM_VERSION_H_
+#define WIDEVINE_CDM_VERSION_STRING \"${widevineConfig.configuredVersion}\"
+#define WIDEVINE_CDM_DOWNLOAD_URL_STRING \"https://redirector.gvt1.com/edgedl/widevine-cdm/${widevineConfig.configuredVersion}-linux-x64.zip\"
+#endif  // WIDEVINE_CDM_VERSION_H_`
+
+    // If version file or fake lib file aren't existed, create them.
+    if (!fs.existsSync(widevineConfig.widevineCdmHeaderFilePath) ||
+        !fs.existsSync(widevineConfig.widevineCdmHeaderFilePath)) {
+      util.doPrepareWidevineCdmBuild(widevineConfig)
+      return
+    }
+
+    // Check version file has latest version. If not create it.
+    // This can prevent unnecessary build by touched version file.
+    const installedHeaderFileContent = fs.readFileSync(widevineConfig.widevineCdmHeaderFilePath, 'utf8')
+    if (installedHeaderFileContent !== widevineConfig.headerFileContent) {
+      console.log("Current version file includes different version with latest")
+      util.doPrepareWidevineCdmBuild(widevineConfig)
+    }
+  },
+
+  doPrepareWidevineCdmBuild: (widevineConfig) => {
+    console.log('prepare widevine cdm build in linux')
+
+    fs.writeFileSync(widevineConfig.widevineCdmHeaderFilePath, widevineConfig.headerFileContent)
+    fs.writeFileSync(widevineConfig.fakeWidevineCdmLibFilePath, '')
+
+    // During the create_dist, /usr/lib/rpm/elfdeps requires that binaries have an exectuable bit set.
+    fs.chmodSync(widevineConfig.fakeWidevineCdmLibFilePath, 0o755)
+  },
+
   signApp: (options = config.defaultOptions) => {
     console.log('signing ...')
 
@@ -218,6 +268,7 @@ const util = {
     console.log('building ' + config.buildTarget + '...')
 
     if (process.platform === 'win32') util.updateOmahaMidlFiles()
+    if (process.platform === 'linux') util.prepareWidevineCdmBuild()
 
     let num_compile_failure = 1
     if (config.ignore_compile_failure)

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
           "url": "https://github.com/brave/brave-core.git"
         }
       }
+    },
+    "widevine": {
+        "version": "4.10.1196.0"
     }
   },
   "repository": {


### PR DESCRIPTION
To build with bundling, we should provide widevine lib and header.
gn checkes that two files during the generation.
Header file is used by brave-core to get latest version and
download url. However, lib file isn't used by brave-core.
So, empty fake lib file is added just for gn.
Real cdm lib is downloaded and initialized when user accepts the
use of widevine.

This pr should be merged with https://github.com/brave/brave-core/pull/1606.

Fix #413

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
1. Start browser with clean profile
2. Load https://bitmovin.com/demos/drm
3. Check No drm
4. Install widevine via content settings bubble
5. Check blocked image text is changed from `not installed` to `not enabled` and bubbles header
   and link text are also changed to `not enabled` and `restart browser`
6. Click restart browser link in bubble
7. Check browser is restarted and widevine is enabled

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
