### PR TITLE
Modifying audit whitelist to include CRLSet URLs

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -5,6 +5,7 @@ const URL = require('url').URL
 const config = require('../lib/config')
 const util = require('../lib/util')
 const whitelistedUrlPrefixes = require('./whitelistedUrlPrefixes')
+const whitelistedUrlPatterns = require('./whitelistedUrlPatterns')
 
 const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options) => {
   config.buildConfig = buildConfig
@@ -147,10 +148,13 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
           return false
         }
         if (url.startsWith('http') && url.includes('.')) {
-          const found = whitelistedUrlPrefixes.find((prefix) => {
+          const foundPrefix = whitelistedUrlPrefixes.find((prefix) => {
             return url.startsWith(prefix)
           })
-          if (!found) {
+          const foundPattern = whitelistedUrlPatterns.find((pattern) => {
+            return RegExp('^' + pattern).test(url)
+          })
+          if (!foundPrefix && !foundPattern) {
             // Check if the URL is a private IP
             try {
               const hostname = new URL(url).hostname

--- a/lib/whitelistedUrlPatterns.js
+++ b/lib/whitelistedUrlPatterns.js
@@ -1,0 +1,5 @@
+// Before adding to this list, get approval from the security team
+module.exports = [
+  'http://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlset2.brave.com
+  'https://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+crl-set.+' // allowed because it 307's to crlset2.brave.com
+]

--- a/lib/whitelistedUrlPrefixes.js
+++ b/lib/whitelistedUrlPrefixes.js
@@ -3,8 +3,6 @@ module.exports = [
   'http://update.googleapis.com/service/update2', // allowed because it 307's to go-updater.brave.com. should never actually connect to googleapis.com.
   'https://update.googleapis.com/service/update2', // allowed because it 307's to go-updater.brave.com. should never actually connect to googleapis.com.
   'https://safebrowsing.googleapis.com/v4/threatListUpdates', // allowed because it 307's to safebrowsing.brave.com
-  'http://redirector.gvt1.com/edgedl/release2/chrome_component/', // allowed because it 307's to crlset2.brave.com
-  'https://redirector.gvt1.com/edgedl/release2/chrome_component/', // allowed because it 307's to crlset2.brave.com
   'https://clients2.googleusercontent.com/crx/blobs/',
   'http://dl.google.com/release2/chrome_component/', // allowed because it 307's to crlset1.brave.com
   'https://dl.google.com/release2/chrome_component/', // allowed because it 307's to crlset1.brave.com


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/3292

# Description

CRLSet component will fetch resources from *.gvt1.com. These requests will be proxied through crlsets2.brave.com

https://github.com/brave/brave-core/pull/1581/files#diff-58c3b6971fd1539fa4e2376e5933752eR53

Add the URLs to the whitelistedURLPrefixes to avoid `test-security` failure.

```
22:47:08  NETWORK AUDIT FAIL: https://r3---sn-nx5s7n7z.gvt1.com/edgedl/release2/chrome_component/SPjVcBe_TC4_4963/4963_all_crl-set-11554432547030691744.data.crx3?cms_redirect=yes&mip=157.52.67.21&mm=28&mn=sn-nx5s7n7z&ms=nvh&mt=1549694115&mv=u&pl=24&shardbypass=yes
22:47:08  NETWORK AUDIT FAIL: https://r4---sn-nx57ynlz.gvt1.com/edgedl/release2/chrome_component/SPjVcBe_TC4_4963/4963_all_crl-set-11554432547030691744.data.crx3?mip=157.52.67.48&pl=24&shardbypass=yes&cms_redirect=yes&mm=28&mn=sn-nx57ynlz&ms=nvh&mt=1549694115&mv=u
22:47:08  NETWORK AUDIT FAIL: https://r1---sn-nx5e6nez.gvt1.com/edgedl/release2/chrome_component/SPjVcBe_TC4_4963/4963_all_crl-set-11554432547030691744.data.crx3?mip=157.52.67.36&pl=24&shardbypass=yes&cms_redirect=yes&mm=28&mn=sn-nx5e6nez&ms=nvh&mt=1549694115&mv=u
22:47:08  NETWORK AUDIT FAIL: https://r5---sn-nx57ynls.gvt1.com/edgedl/release2/chrome_component/SPjVcBe_TC4_4963/4963_all_crl-set-11554432547030691744.data.crx3?mip=157.52.67.22&pl=24&shardbypass=yes&cms_redirect=yes&mm=28&mn=sn-nx57ynls&ms=nvh&mt=1549694115&mv=u
```

This change:

1. Updates prefix whitelisting to use RegExp to handle wildcard prefixes
2. Update audit whitelist to include CRLSet URLs

auditors: @diracdeltas

# Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:

1. Run `npm run test-security`
2. tests should pass

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
