### PR TITLE
Issue 3334: Fix lint script for uplift requests

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -279,11 +279,15 @@ const util = {
     util.run('ninja', ['-C', config.outputDir, config.buildTarget, '-k', num_compile_failure], options)
   },
 
-  lint: (options = {}) => {
+  lint: (options) => {
+    if (!options) {
+      options = 'origin/master';
+    }
     let cmd_options = config.defaultOptions
     cmd_options.cwd = config.projects['brave-core'].dir
     util.run('python', [path.join(config.rootDir, 'scripts', 'lint.py'),
-        '--project_root=' + config.srcDir], cmd_options)
+        '--project_root=' + config.srcDir,
+        '--base_branch=' + options], cmd_options)
   },
 
   submoduleSync: (options = {}) => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -279,15 +279,15 @@ const util = {
     util.run('ninja', ['-C', config.outputDir, config.buildTarget, '-k', num_compile_failure], options)
   },
 
-  lint: (options) => {
-    if (!options) {
-      options = 'origin/master';
+  lint: (options = {}) => {
+    if (!options.base) {
+      options.base = 'origin/master';
     }
     let cmd_options = config.defaultOptions
     cmd_options.cwd = config.projects['brave-core'].dir
     util.run('python', [path.join(config.rootDir, 'scripts', 'lint.py'),
         '--project_root=' + config.srcDir,
-        '--base_branch=' + options], cmd_options)
+        '--base_branch=' + options.base], cmd_options)
   },
 
   submoduleSync: (options = {}) => {

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -130,6 +130,8 @@ program
 
 program
   .command('lint')
+  .option('--base', 'set the destination branch for the PR')
+  .arguments('[build_config]')
   .action(util.lint)
 
 program

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -130,8 +130,7 @@ program
 
 program
   .command('lint')
-  .option('--base', 'set the destination branch for the PR')
-  .arguments('[build_config]')
+  .option('--base <base branch>', 'set the destination branch for the PR')
   .action(util.lint)
 
 program

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -49,10 +49,8 @@ def main(args):
   os.chdir(settings.GetRoot())
   try:
     cl = git_cl.Changelist(auth_config=auth_config)
-    upstream = git_common.get_or_create_merge_base(cl.GetBranch(), options.base_branch)
-    changed_files_cmd = git_cl.BuildGitDiffCmd('--name-only', upstream, "")
-    diff_output = git_cl.RunGit(changed_files_cmd)
-    files = diff_output.splitlines()
+    change = cl.GetChange(git_common.get_or_create_merge_base(cl.GetBranch(), options.base_branch), None)
+    files = [f.LocalPath() for f in change.AffectedFiles()]
     if not files:
       print('Cannot lint an empty CL')
       return 0


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/3334

## Description

script/lint.py uses GetCommonAncestorWithUpstream() which returns common ancestor with the master branch. This fixes lint script by passing a base branch from config to compute the list of files changed by the commit.

auditors: @bridiver, @mihaiplesa, @bsclifton

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:

`master_lint_dummy` - is a dummy branch off `master`
1. Checkout `lint_fix`
2.  Checkout `master_lint_dummy` in `src/brave`
3. `npm run lint` should show lint errors for 5 files (8 errors)

`test_lint_dummy_0.62.x` - is a dummy branch off `0.62.x`

1. Checkout `test_lint_dummy_0.62.x` in `src/brave`
2. `npm run lint -- --base=origin/0.62.x` should show lint errors for 5 files (13 errors)

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
