### PR TITLE
Fixes package.json to point to 0.61.x brave-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       },
       "brave-core": {
         "dir": "src/brave",
-        "branch": "master",
+        "branch": "0.61.x",
         "repository": {
           "url": "https://github.com/brave/brave-core.git"
         }


### PR DESCRIPTION
Fixes brave/brave-browser#3360
