### PR TITLE
Don't install optional npm packages on macOS for CI runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,7 +223,7 @@ pipeline {
                         }
                         stage("install") {
                             steps {
-                                sh "npm install"
+                                sh "npm install --no-optional"
                             }
                         }
                         stage("init") {


### PR DESCRIPTION
Fixes problem where fsevents is not available on macOS (optional dep not used for CI runs; errors because no binary for node 11)

Error shown in our logs like:
```
12:31:19  0> Downloading src/third_party/node/node_modules.tar.gz...
12:31:20  node-pre-gyp WARN Tried to download(404): https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.2.4/fse-v1.2.4-node-v67-darwin-x64.tar.gz 
12:31:20  node-pre-gyp WARN Pre-built binaries not found for fsevents@1.2.4 and node@11.9.0 (node-v67 ABI, unknown) (falling back to source compile with node-gyp) 
12:31:20  gyp WARN install got an error, rolling back install
12:31:20  gyp ERR! configure error 
12:31:20  gyp ERR! stack Error: 404 response downloading https://brave-brave-binaries.s3.amazonaws.com/releases/dist/v11.9.0/node-v11.9.0-headers.tar.gz
12:31:20  gyp ERR! stack     at Request.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/install.js:214:14)
12:31:20  gyp ERR! stack     at Request.emit (events.js:202:15)
12:31:20  gyp ERR! stack     at Request.onRequestResponse (/usr/local/lib/node_modules/npm/node_modules/request/request.js:1066:10)
12:31:20  gyp ERR! stack     at ClientRequest.emit (events.js:197:13)
12:31:20  gyp ERR! stack     at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:562:21)
12:31:20  gyp ERR! stack     at HTTPParser.parserOnHeadersComplete (_http_common.js:113:17)
12:31:20  gyp ERR! stack     at TLSSocket.socketOnData (_http_client.js:449:20)
12:31:20  gyp ERR! stack     at TLSSocket.emit (events.js:197:13)
12:31:20  gyp ERR! stack     at addChunk (_stream_readable.js:288:12)
12:31:20  gyp ERR! stack     at readableAddChunk (_stream_readable.js:269:11)
```