### PR TITLE
Make build step sign binaries and generate widevine sig files on Windows

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -100,6 +100,16 @@ const build = (buildConfig = config.defaultBuildConfig, options) => {
   if (config.shouldSign()) {
     util.signApp()
   }
+
+  if (process.platform === 'win32') {
+    util.signWinBinaries()
+
+    if (config.brave_enable_cdm_host_verification) {
+      util.generateWidevineSigFiles()
+    }
+  }
+
+
 }
 
 module.exports = build

--- a/lib/config.js
+++ b/lib/config.js
@@ -53,6 +53,11 @@ const Config = function () {
   this.ignore_compile_failure = false
   this.enable_hangout_services_extension = true
   this.widevineVersion = getNPMConfig(['widevine', 'version'])
+  this.brave_enable_cdm_host_verification = false
+  this.sign_widevine_cert = process.env.SIGN_WIDEVINE_CERT || ''
+  this.sign_widevine_key = process.env.SIGN_WIDEVINE_KEY || ''
+  this.sign_widevine_passwd = process.env.SIGN_WIDEVINE_PASSPHRASE || ''
+  this.signature_generator = path.join(this.srcDir, 'third_party', 'widevine', 'scripts', 'signature_generator.py') || ''
 }
 
 Config.prototype.buildArgs = function () {
@@ -91,7 +96,8 @@ Config.prototype.buildArgs = function () {
     chrome_version_major: chrome_version_parts[0],
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
     brave_referrals_api_key: this.braveReferralsApiKey,
-    enable_hangout_services_extension: this.enable_hangout_services_extension
+    enable_hangout_services_extension: this.enable_hangout_services_extension,
+    brave_enable_cdm_host_verification: this.brave_enable_cdm_host_verification,
   }
 
   if (process.platform === 'darwin') {
@@ -283,6 +289,18 @@ Config.prototype.update = function (options) {
   } else if (options.channel !== 'release') {
     // In chromium src, empty string represents stable channel.
     this.channel = options.channel
+  }
+
+  if (this.buildConfig === 'Release' && process.platform !== 'linux') {
+    this.brave_enable_cdm_host_verification =
+        this.sign_widevine_cert !== "" && this.sign_widevine_key !== "" &&
+        this.sign_widevine_passwd !== "" && fs.existsSync(this.signature_generator)
+
+    if (this.brave_enable_cdm_host_verification) {
+      console.log('Widevine cdm host verification is enabled')
+    } else {
+      console.log('Widevine cdm host verification is disabled')
+    }
   }
 
   if (process.platform === 'win32' && options.build_omaha) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -264,6 +264,49 @@ const util = {
     util.run('ninja', ['-C', config.outputDir, config.signTarget], options)
   },
 
+  signWinBinaries: () => {
+    if (!config.buildConfig === 'Release' || config.skip_signing) {
+      console.log('binary signing is skipped because this is not ofiicial build or --skip_signing is used')
+      return
+    }
+
+    if (process.env.CERT === undefined || process.env.SIGNTOOL_ARGS === undefined) {
+      console.log('binary signing is skipped because of missing env vars')
+      return
+    }
+
+    console.log('signing win binaries...')
+
+    const core_dir = config.projects['brave-core'].dir
+    util.run('python', [path.join(core_dir, 'script', 'sign_binaries.py'),
+        '--build_dir=' + path.join(config.srcDir, 'out', 'Release')])
+  },
+
+  generateWidevineSigFiles: () => {
+    const cert = config.sign_widevine_cert
+    const key = config.sign_widevine_key
+    const passwd = config.sign_widevine_passwd
+    const sig_generator = config.signature_generator
+
+    console.log('generate Widevine sig files...')
+
+    util.run('python', [sig_generator, '--input_file=' + path.join(config.srcDir, 'out', 'Release', 'brave.exe'),
+        '--flags=1',
+        '--certificate=' + cert,
+        '--private_key=' + key,
+        '--private_key_passphrase=' + passwd])
+   util.run('python', [sig_generator, '--input_file=' + path.join(config.srcDir, 'out', 'Release', 'chrome.dll'),
+        '--flags=0',
+        '--certificate=' + cert,
+        '--private_key=' + key,
+        '--private_key_passphrase=' + passwd])
+    util.run('python', [sig_generator, '--input_file=' + path.join(config.srcDir, 'out', 'Release', 'chrome_child.dll'),
+        '--flags=0',
+        '--certificate=' + cert,
+        '--private_key=' + key,
+        '--private_key_passphrase=' + passwd])
+  },
+
   buildTarget: (options = config.defaultOptions) => {
     console.log('building ' + config.buildTarget + '...')
 

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -39,6 +39,7 @@ program
   .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
   .option('--channel <target_chanel>', 'target channel to build', /^(beta|dev|nightly|release)$/i, 'release')
   .option('--ignore_compile_failure', 'Keep compiling regardless of error')
+  .option('--skip_signing', 'skip signing binaries')
   .arguments('[build_config]')
   .action(build)
 


### PR DESCRIPTION
Signing is moved from `create_dist` step because signed binaries are
needed to generate sig files. And sig files can't be generated by gn
because of python version of depot_tools.
So, build step signes and generates sig files by system python and they
will be used by installer packaging.

Issue: https://github.com/brave/brave-browser/issues/944

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [x] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:
Please refer Test plan at
https://github.com/brave/brave-core/pull/2023

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
