### PR TITLE
Pass is_debug by config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -49,7 +49,6 @@ const Config = function () {
   this.gypTargetArch = 'x64'
   this.targetApkBase ='classic'
   this.officialBuild = true
-  this.debugBuild = JSON.parse(getNPMConfig(['brave_debug_build']) || false)
   this.braveGoogleApiKey = getNPMConfig(['brave_google_api_key']) || 'AIzaSyAQfxPJiounkhOjODEO5ZieffeBv6yft2Q'
   this.googleApiKey = getNPMConfig(['google_api_key']) || 'AIzaSyAH90V94EcZBP5oH7oc-mXQrSKgASVxER8'
   this.googleApiEndpoint = getNPMConfig(['brave_google_api_endpoint']) || 'https://www.googleapis.com/geolocation/v1/geolocate?key='
@@ -101,7 +100,6 @@ Config.prototype.buildArgs = function () {
     target_cpu: this.targetArch,
     target_apk_base: this.targetApkBase,
     is_official_build: this.officialBuild,
-    is_debug: this.buildConfig !== 'Release',
     dcheck_always_on: this.buildConfig !== 'Release',
     brave_channel: this.channel,
     google_api_key: this.googleApiKey,
@@ -138,13 +136,18 @@ Config.prototype.buildArgs = function () {
     args.skip_signing = true
   }
 
-  if (this.debugBuild && this.targetOS !== 'ios') {
-    if (process.platform === 'darwin') {
-      args.enable_stripping = false
+  if (this.debugBuild !== undefined &&
+      this.debugBuild !== null &&
+      this.targetOS !== 'ios') {
+    if (this.debugBuild) {
+      if (process.platform === 'darwin') {
+        args.enable_stripping = false
+      }
+      args.symbol_level = 2
+      args.enable_profiling = true
+      args.is_win_fastlink = true
     }
-    args.symbol_level = 2
-    args.enable_profiling = true
-    args.is_win_fastlink = true
+    args.is_debug = this.debugBuild
   }
 
   if (this.sccache && process.platform === 'win32') {
@@ -361,15 +364,10 @@ Config.prototype.update = function (options) {
 
   if (options.debug_build !== null && options.debug_build !== undefined) {
     this.debugBuild = JSON.parse(options.debug_build)
-  } else {
-    this.debugBuild = this.buildConfig !== 'Release'
   }
 
   if (options.official_build !== null && options.official_build !== undefined) {
     this.officialBuild = JSON.parse(options.official_build)
-    if (this.officialBuild) {
-      this.debugBuild = false
-    }
   } else {
     this.officialBuild = this.buildConfig === 'Release'
   }


### PR DESCRIPTION
 and this allow us to do is_debug=true for Release build for debug purpose

fix https://github.com/brave/brave-browser/issues/3905

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
