### PR TITLE
Issue 3927: Whitelist storage.googleapis.com which is now proxied though crlsets.brave.com

### DIFF
--- a/lib/whitelistedUrlPatterns.js
+++ b/lib/whitelistedUrlPatterns.js
@@ -3,5 +3,7 @@ module.exports = [
   'http://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
   'https://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
   'http://www.google.com/dl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
-  'https://www.google.com/dl/release2/chrome_component/.+crl-set.+' // allowed because it 307's to crlsets.brave.com
+  'https://www.google.com/dl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
+  'http://storage.googleapis.com/update-delta/hfnkpimlhhgieaddgfemjhofmfblmnib/.+crxd', // allowed because it 307's to crlsets.brave.com,
+  'https://storage.googleapis.com/update-delta/hfnkpimlhhgieaddgfemjhofmfblmnib/.+crxd' // allowed because it 307's to crlsets.brave.com
 ]


### PR DESCRIPTION
PR builder passed here: https://staging.ci.brave.com/job/brave-browser-build-pr/job/PR-3929/

## Description

fix #3927 

CRLSets on windows started requesting resources from storage.googleapis.com. We updated the redirector to proxy requests for these resources: https://github.com/brave/redirector/commit/372e4426582c11d4dcd2ab57da9567c5c12b172c

This PR adds `storage.googleapis` to the network audit whitelist since requests to the URL will be proxied through the redirector.

PR to proxy requests in brave-core: https://github.com/brave/brave-core/pull/2114/files

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan: 
1. Covered by automated tests

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
