### PR TITLE
Revert "added widevine steps to pipeline"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,9 +203,6 @@ pipeline {
                     environment {
                         GIT_CACHE_PATH = "${HOME}/cache"
                         SCCACHE_BUCKET = credentials("brave-browser-sccache-mac-s3-bucket")
-                        SIGN_WIDEVINE_CERT = credentials("widevine_brave_prod_cert.der")
-                        SIGN_WIDEVINE_KEY = credentials("widevine_brave_prod_key.pem")
-                        SIGN_WIDEVINE_PASSPHRASE = credentials("447b2fa7-c989-43af-9047-8ae158fad0a3")
                     }
                     stages {
                         stage("checkout") {
@@ -277,9 +274,6 @@ pipeline {
                                     npm config --userconfig=.npmrc set brave_google_api_key ${BRAVE_GOOGLE_API_KEY}
                                     npm config --userconfig=.npmrc set google_api_endpoint safebrowsing.brave.com
                                     npm config --userconfig=.npmrc set google_api_key dummytoken
-
-                                    mkdir -p src/third_party/widevine/scripts/
-                                    cp ${HOME}/signature_generator.py src/third_party/widevine/scripts/
 
                                     npm run build -- ${BUILD_TYPE} --channel=${CHANNEL} --official_build=true
                                 """
@@ -393,9 +387,6 @@ pipeline {
                         KEY_PFX_PATH = "C:\\jenkins\\digicert-key\\digicert.pfx"
                         AUTHENTICODE_PASSWORD = credentials("digicert-brave-browser-development-certificate-ps-escaped")
                         AUTHENTICODE_PASSWORD_UNESCAPED = credentials("digicert-brave-browser-development-certificate")
-                        SIGN_WIDEVINE_CERT = credentials("widevine_brave_prod_cert.der")
-                        SIGN_WIDEVINE_KEY = credentials("widevine_brave_prod_key.pem")
-                        SIGN_WIDEVINE_PASSPHRASE = credentials("447b2fa7-c989-43af-9047-8ae158fad0a3")
                     }
                     stages {
                         stage("checkout") {
@@ -467,9 +458,6 @@ pipeline {
                                     npm config --userconfig=.npmrc set brave_google_api_key ${BRAVE_GOOGLE_API_KEY}
                                     npm config --userconfig=.npmrc set google_api_endpoint safebrowsing.brave.com
                                     npm config --userconfig=.npmrc set google_api_key dummytoken
-
-                                    New-Item -ItemType directory -Path "src\\third_party\\widevine\\scripts"
-                                    Copy-Item "C:\\jenkins\\signature_generator.py" -Destination "src\\third_party\\widevine\\scripts\\"
 
                                     npm run build -- ${BUILD_TYPE} --channel=${CHANNEL} --official_build=true
                                 """
@@ -606,9 +594,6 @@ pipeline {
                         KEY_PFX_PATH = "C:\\jenkins\\digicert-key\\digicert.pfx"
                         AUTHENTICODE_PASSWORD = credentials("digicert-brave-browser-development-certificate-ps-escaped")
                         AUTHENTICODE_PASSWORD_UNESCAPED = credentials("digicert-brave-browser-development-certificate")
-                        SIGN_WIDEVINE_CERT = credentials("widevine_brave_prod_cert.der")
-                        SIGN_WIDEVINE_KEY = credentials("widevine_brave_prod_key.pem")
-                        SIGN_WIDEVINE_PASSPHRASE = credentials("447b2fa7-c989-43af-9047-8ae158fad0a3")
                     }
                     stages {
                         stage("checkout") {
@@ -680,9 +665,6 @@ pipeline {
                                     npm config --userconfig=.npmrc set brave_google_api_key ${BRAVE_GOOGLE_API_KEY}
                                     npm config --userconfig=.npmrc set google_api_endpoint safebrowsing.brave.com
                                     npm config --userconfig=.npmrc set google_api_key dummytoken
-
-                                    New-Item -ItemType directory -Path "src\\third_party\\widevine\\scripts"
-                                    Copy-Item "C:\\jenkins\\signature_generator.py" -Destination "src\\third_party\\widevine\\scripts\\"
 
                                     npm run build -- ${BUILD_TYPE} --channel=${CHANNEL} --official_build=true --target_arch=ia32
                                 """

--- a/lib/util.js
+++ b/lib/util.js
@@ -278,7 +278,8 @@ const util = {
     console.log('signing win binaries...')
 
     const core_dir = config.projects['brave-core'].dir
-    util.run('python', [path.join(core_dir, 'script', 'sign_binaries.py'), '--build_dir=' + config.outputDir])
+    util.run('python', [path.join(core_dir, 'script', 'sign_binaries.py'),
+        '--build_dir=' + path.join(config.srcDir, 'out', 'Release')])
   },
 
   generateWidevineSigFiles: () => {


### PR DESCRIPTION
Reverts brave/brave-browser#3981

Reason: Windows PR builder fails with binary signing.