### PR TITLE
Issue 4030: Using SIGKILL instead of SIGTERM to terminate the process on timeout

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -94,7 +94,8 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
     stdio: 'inherit',
     timeout: options.network_log ? 120000 : undefined,
     continueOnFail: options.network_log ? true : false,
-    shell: process.platform === 'darwin' ? true : false
+    shell: process.platform === 'darwin' ? true : false,
+    killSignal: options.network_log && process.env.RELEASE_TYPE ? 'SIGKILL' : 'SIGTERM'
   }
 
   if (options.network_log) {


### PR DESCRIPTION
fix #4030  

**PR Builder passed here**: https://staging.ci.brave.com/job/brave-browser-build-pr/job/PR-4036/4/

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:

1. Verify that `npm run test-security` works on build machines.
2. Remove any entry from `lib/whitelistedUrlPrefixes.js` and confirm it fails.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
