### PR TITLE
Fix `npm run test-security` issue which was breaking builds

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -94,7 +94,8 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
     stdio: 'inherit',
     timeout: options.network_log ? 120000 : undefined,
     continueOnFail: options.network_log ? true : false,
-    shell: process.platform === 'darwin' ? true : false
+    shell: process.platform === 'darwin' ? true : false,
+    killSignal: options.network_log && process.env.RELEASE_TYPE ? 'SIGKILL' : 'SIGTERM'
   }
 
   if (options.network_log) {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/4036
Fixes https://github.com/brave/brave-browser/issues/4030