### PR TITLE
Update audit script used by `npm run test-security` to skip vendor fo…

### DIFF
--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -16,7 +16,8 @@ const syncDir = path.join(braveDir, 'components', 'brave_sync', 'extension')
  */
 function npmAudit (pathname) {
   if (fs.existsSync(path.join(pathname, 'package.json')) &&
-    fs.existsSync(path.join(pathname, 'package-lock.json'))) {
+    fs.existsSync(path.join(pathname, 'package-lock.json')) &&
+    fs.existsSync(path.join(pathname, 'node_modules'))) {
     console.log('Auditing', pathname)
     let cmdOptions = {
       cwd: pathname,
@@ -24,7 +25,7 @@ function npmAudit (pathname) {
     }
     util.run('npm', ['audit'], cmdOptions)
   } else {
-    console.log('Skipping audit of', pathname)
+    console.log('Skipping audit of "' + pathname + '" (no package.json or node_modules directory found)')
   }
 }
 


### PR DESCRIPTION
…lders which are not actively using node.js (ex: they may use node, but only for tests, etc)

Fixes https://github.com/brave/brave-browser/issues/4075

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
