### PR TITLE
fixed build param init in pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,9 @@ pipeline {
         BRANCH = "${params.BRANCH}"
         CHANNEL = "${params.CHANNEL}"
         CHANNEL_CAPITALIZED = "${CHANNEL}".capitalize()
+        WIPE_WORKSPACE = "${params.WIPE_WORKSPACE}"
+        RUN_INIT = "${params.RUN_INIT}"
+        DISABLE_SCCACHE = "${params.DISABLE_SCCACHE}"        
         BUILD_TYPE = "Release"
         OUT_DIR = "src/out/${BUILD_TYPE}"
         LINT_BRANCH = "TEMP_LINT_BRANCH_${BUILD_NUMBER}"


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.
