### PR TITLE
Upgrade from Chromium "74.0.3729.108" to Chromium 74.0.3729.131

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "74.0.3729.108",
+        "tag": "74.0.3729.131",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/4281 to `0.64.x`

Fixes https://github.com/brave/brave-browser/issues/4278

Merge pull request #4281 from brave/74.0.3729.131_master_22
