### PR TITLE
multiple CI pipeline fixes and improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent none
     options {
-        disableConcurrentBuilds()
+        // TODO: set max. no. of concurrent builds to 2
         timeout(time: 12, unit: "HOURS")
         timestamps()
     }
@@ -19,12 +19,14 @@ pipeline {
         BRAVE_GOOGLE_API_KEY = credentials("npm_config_brave_google_api_key")
         BRAVE_ARTIFACTS_BUCKET = credentials("brave-jenkins-artifacts-s3-bucket")
         BRAVE_S3_BUCKET = credentials("brave-binaries-s3-bucket")
+        SLACK_USERNAME_MAP = credentials("github-to-slack-username-map")
     }
     stages {
         stage("env") {
             steps {
                 script {
                     BRANCH = params.BRANCH
+                    BRANCH_TO_BUILD = (env.CHANGE_BRANCH.equals(null) ? BRANCH : env.CHANGE_BRANCH)
                     CHANNEL = params.CHANNEL
                     CHANNEL_CAPITALIZED = CHANNEL.capitalize()
                     WIPE_WORKSPACE = params.WIPE_WORKSPACE
@@ -35,42 +37,70 @@ pipeline {
                     OUT_DIR = "src/out/" + BUILD_TYPE
                     LINT_BRANCH = "TEMP_LINT_BRANCH_" + BUILD_NUMBER
                     RELEASE_TYPE = (env.JOB_NAME.equals("brave-browser-build") ? "release" : "ci")
-                    BRANCH_TO_BUILD = (env.CHANGE_BRANCH.equals(null) ? BRANCH : env.CHANGE_BRANCH)
                     BRAVE_GITHUB_TOKEN = "brave-browser-releases-github"
                     GITHUB_API = "https://api.github.com/repos/brave"
                     GITHUB_CREDENTIAL_ID = "brave-builds-github-token-for-pr-builder"
-                    BRANCH_EXISTS_IN_BC = httpRequest(url: GITHUB_API + "/brave-core/branches/" + BRANCH_TO_BUILD, validResponseCodes: '100:499', authentication: GITHUB_CREDENTIAL_ID, quiet: !DEBUG).status.equals(200)
                     TARGET_BRANCH = "master"
-                    SKIP = false
                     if (env.CHANGE_BRANCH) {
                         TARGET_BRANCH = env.CHANGE_TARGET
-                        prNumber = readJSON(text: httpRequest(url: GITHUB_API + "/brave-browser/pulls?head=brave:" + BRANCH_TO_BUILD, authentication: GITHUB_CREDENTIAL_ID, quiet: !DEBUG).content)[0].number
-                        prDetails = readJSON(text: httpRequest(url: GITHUB_API + "/brave-browser/pulls/" + prNumber, authentication: GITHUB_CREDENTIAL_ID, quiet: !DEBUG).content)
-                        SKIP = prDetails.mergeable_state.equals("draft") or prDetails.labels.count { label -> label.name.equals("CI/Skip") }.equals(1)
+                        def prNumber = readJSON(text: httpRequest(url: GITHUB_API + "/brave-browser/pulls?head=brave:" + BRANCH_TO_BUILD, authentication: GITHUB_CREDENTIAL_ID, quiet: !DEBUG).content)[0].number
+                        def prDetails = readJSON(text: httpRequest(url: GITHUB_API + "/brave-browser/pulls/" + prNumber, authentication: GITHUB_CREDENTIAL_ID, quiet: !DEBUG).content)
+                        env.SKIP = prDetails.mergeable_state.equals("draft") or prDetails.labels.count { label -> label.name.equals("CI/Skip") }.equals(1)
+                        env.SLACK_USERNAME = readJSON(text: SLACK_USERNAME_MAP)[env.CHANGE_AUTHOR]
+                        if (env.SLACK_USERNAME) {
+                            slackSend(color:null, channel: env.SLACK_USERNAME, message: "STARTED - ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}/flowGraphTable/?auto_refresh=true|Open>)")
+                        }
+                    }
+                    BRANCH_EXISTS_IN_BC = httpRequest(url: GITHUB_API + "/brave-core/branches/" + BRANCH_TO_BUILD, validResponseCodes: "100:499", authentication: GITHUB_CREDENTIAL_ID, quiet: !DEBUG).status.equals(200)
+                    if (BRANCH_EXISTS_IN_BC) {
+                        def bcPrDetails = readJSON(text: httpRequest(url: GITHUB_API + "/brave-core/pulls?head=brave:" + BRANCH_TO_BUILD, authentication: GITHUB_CREDENTIAL_ID, quiet: !DEBUG).content)[0]
+                        if (bcPrDetails) {
+                            env.BC_PR_NUMBER = bcPrDetails.number
+                        }
                     }
                 }
             }
         }
-        stage("continue") {
-            when {
-                beforeAgent true
-                expression { SKIP }
-            }
+        stage("abort") {
             steps {
                 script {
-                    print "PR is in draft or has \"CI/Skip\" label, aborting build!"
-                    currentBuild.result = "ABORTED"
+                    if (env.SKIP == true) {
+                        print "Aborting build as PR is in draft or has \"CI/Skip\" label."
+                        stopCurrentBuild()
+                    }
+                    else if (BRANCH_EXISTS_IN_BC) {
+                        if (isStartedManually()) {
+                            if (env.BC_PR_NUMBER) {
+                                print "Aborting build as PR exists in brave-core and build has not been started from there."
+                                print "Use " + env.JENKINS_URL + "view/ci/job/brave-core-build-pr/view/change-requests/job/PR-" + env.BC_PR_NUMBER + " to trigger."
+                            }
+                            else {
+                                print "Aborting build as there's a matching branch in brave-core, please create a PR there first."
+                                print "Use https://github.com/brave/brave-core/compare/" + TARGET_BRANCH + "..." + BRANCH_TO_BUILD + " to create PR."
+                            }
+                            env.SKIP = true
+                            stopCurrentBuild()
+                        }
+                    }
+                    for (build in getBuilds()) {
+                        if (build.isBuilding() && build.getNumber() < env.BUILD_NUMBER.toInteger()) {
+                            print "Aborting older running build " + build
+                            build.doStop()
+                            // build.finish(hudson.model.Result.ABORTED, new java.io.IOException("Aborting build"))
+                        }
+                    }
+                    sleep(time: 1, unit: "MINUTES")
                 }
             }
         }
         stage("build-all") {
             when {
                 beforeAgent true
-                expression { !SKIP }
+                expression { env.SKIP != true }
             }
             parallel {
                 stage("android") {
-                    agent { label "linux-${RELEASE_TYPE}" }
+                    agent { label "android-${RELEASE_TYPE}" }
                     environment {
                         GIT_CACHE_PATH = "${HOME}/cache"
                         SCCACHE_BUCKET = credentials("brave-browser-sccache-android-s3-bucket")
@@ -84,7 +114,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                checkout([$class: 'GitSCM', branches: [[name: "${BRANCH_TO_BUILD}"]], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/brave/brave-browser.git']]])
+                                checkout([$class: "GitSCM", branches: [[name: "${BRANCH_TO_BUILD}"]], extensions: [[$class: "WipeWorkspace"]], userRemoteConfigs: [[url: "https://github.com/brave/brave-browser.git"]]])
                             }
                         }
                         stage("pin") {
@@ -93,6 +123,7 @@ pipeline {
                             }
                             steps {
                                 sh """
+                                    set -e
                                     jq 'del(.config.projects["brave-core"].branch) | .config.projects["brave-core"].branch="${BRANCH_TO_BUILD}"' package.json > package.json.new
                                     mv package.json.new package.json
                                 """
@@ -122,6 +153,7 @@ pipeline {
                                 script {
                                     try {
                                         sh """
+                                            set -e
                                             git -C src/brave config user.name brave-builds
                                             git -C src/brave config user.email devops@brave.com
                                             git -C src/brave checkout -b ${LINT_BRANCH}
@@ -151,6 +183,7 @@ pipeline {
                         stage("build") {
                             steps {
                                 sh """
+                                    set -e
                                     npm config --userconfig=.npmrc set brave_referrals_api_key ${REFERRAL_API_KEY}
                                     npm config --userconfig=.npmrc set brave_google_api_endpoint https://location.services.mozilla.com/v1/geolocate?key=
                                     npm config --userconfig=.npmrc set brave_google_api_key ${BRAVE_GOOGLE_API_KEY}
@@ -186,7 +219,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                checkout([$class: 'GitSCM', branches: [[name: "${BRANCH_TO_BUILD}"]], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/brave/brave-browser.git']]])
+                                checkout([$class: "GitSCM", branches: [[name: "${BRANCH_TO_BUILD}"]], extensions: [[$class: "WipeWorkspace"]], userRemoteConfigs: [[url: "https://github.com/brave/brave-browser.git"]]])
                             }
                         }
                         stage("pin") {
@@ -195,6 +228,7 @@ pipeline {
                             }
                             steps {
                                 sh """
+                                    set -e
                                     jq 'del(.config.projects["brave-core"].branch) | .config.projects["brave-core"].branch="${BRANCH_TO_BUILD}"' package.json > package.json.new
                                     mv package.json.new package.json
                                 """
@@ -224,6 +258,7 @@ pipeline {
                                 script {
                                     try {
                                         sh """
+                                            set -e
                                             git -C src/brave config user.name brave-builds
                                             git -C src/brave config user.email devops@brave.com
                                             git -C src/brave checkout -b ${LINT_BRANCH}
@@ -234,6 +269,20 @@ pipeline {
                                     }
                                     catch (ex) {
                                         currentBuild.result = "UNSTABLE"
+                                    }
+                                }
+                            }
+                        }
+                        stage("audit-deps") {
+                            steps {
+                                timeout(time: 2, unit: "MINUTES") {
+                                    script {
+                                        try {
+                                            sh "npm run audit_deps"
+                                        }
+                                        catch (ex) {
+                                            currentBuild.result = "UNSTABLE"
+                                        }
                                     }
                                 }
                             }
@@ -253,6 +302,7 @@ pipeline {
                         stage("build") {
                             steps {
                                 sh """
+                                    set -e
                                     npm config --userconfig=.npmrc set brave_referrals_api_key ${REFERRAL_API_KEY}
                                     npm config --userconfig=.npmrc set brave_google_api_endpoint https://location.services.mozilla.com/v1/geolocate?key=
                                     npm config --userconfig=.npmrc set brave_google_api_key ${BRAVE_GOOGLE_API_KEY}
@@ -262,26 +312,12 @@ pipeline {
                                 """
                             }
                         }
-                        stage("network-audit") {
+                        stage("audit-network") {
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     script {
                                         try {
                                             sh "npm run network-audit -- --output_path=\"${OUT_DIR}/brave\""
-                                        }
-                                        catch (ex) {
-                                            currentBuild.result = "UNSTABLE"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        stage("audit_deps") {
-                            steps {
-                                timeout(time: 2, unit: "MINUTES") {
-                                    script {
-                                        try {
-                                            sh "npm run audit_deps"
                                         }
                                         catch (ex) {
                                             currentBuild.result = "UNSTABLE"
@@ -352,7 +388,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                checkout([$class: 'GitSCM', branches: [[name: "${BRANCH_TO_BUILD}"]], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/brave/brave-browser.git']]])
+                                checkout([$class: "GitSCM", branches: [[name: "${BRANCH_TO_BUILD}"]], extensions: [[$class: "WipeWorkspace"]], userRemoteConfigs: [[url: "https://github.com/brave/brave-browser.git"]]])
                             }
                         }
                         stage("pin") {
@@ -361,6 +397,7 @@ pipeline {
                             }
                             steps {
                                 sh """
+                                    set -e
                                     jq 'del(.config.projects["brave-core"].branch) | .config.projects["brave-core"].branch="${BRANCH_TO_BUILD}"' package.json > package.json.new
                                     mv package.json.new package.json
                                 """
@@ -368,6 +405,7 @@ pipeline {
                         }
                         stage("install") {
                             steps {
+                                buildName "${BUILD_NUMBER}-${BRANCH_TO_BUILD}-"+"${GIT_COMMIT}".substring(0, 7)
                                 sh "npm install --no-optional"
                                 sh "rm -rf ${GIT_CACHE_PATH}/*.lock"
                             }
@@ -390,6 +428,7 @@ pipeline {
                                 script {
                                     try {
                                         sh """
+                                            set -e
                                             git -C src/brave config user.name brave-builds
                                             git -C src/brave config user.email devops@brave.com
                                             git -C src/brave checkout -b ${LINT_BRANCH}
@@ -400,6 +439,20 @@ pipeline {
                                     }
                                     catch (ex) {
                                         currentBuild.result = "UNSTABLE"
+                                    }
+                                }
+                            }
+                        }
+                        stage("audit-deps") {
+                            steps {
+                                timeout(time: 2, unit: "MINUTES") {
+                                    script {
+                                        try {
+                                            sh "npm run audit_deps"
+                                        }
+                                        catch (ex) {
+                                            currentBuild.result = "UNSTABLE"
+                                        }
                                     }
                                 }
                             }
@@ -419,6 +472,7 @@ pipeline {
                         stage("build") {
                             steps {
                                 sh """
+                                    set -e
                                     npm config --userconfig=.npmrc set brave_referrals_api_key ${REFERRAL_API_KEY}
                                     npm config --userconfig=.npmrc set brave_google_api_endpoint https://location.services.mozilla.com/v1/geolocate?key=
                                     npm config --userconfig=.npmrc set brave_google_api_key ${BRAVE_GOOGLE_API_KEY}
@@ -428,26 +482,12 @@ pipeline {
                                 """
                             }
                         }
-                        stage("network-audit") {
+                        stage("audit-network") {
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     script {
                                         try {
                                             sh "npm run network-audit -- --output_path=\"${OUT_DIR}/Brave\\ Browser\\ ${CHANNEL_CAPITALIZED}.app/Contents/MacOS/Brave\\ Browser\\ ${CHANNEL_CAPITALIZED}\""
-                                        }
-                                        catch (ex) {
-                                            currentBuild.result = "UNSTABLE"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        stage("audit_deps") {
-                            steps {
-                                timeout(time: 2, unit: "MINUTES") {
-                                    script {
-                                        try {
-                                            sh "npm run audit_deps"
                                         }
                                         catch (ex) {
                                             currentBuild.result = "UNSTABLE"
@@ -486,20 +526,9 @@ pipeline {
                                 }
                             }
                         }
-                        stage("dist-ci") {
-                            when {
-                                expression { "${RELEASE_TYPE}" == "ci" }
-                            }
+                        stage("dist") {
                             steps {
                                 sh "npm run create_dist -- ${BUILD_TYPE} --channel=${CHANNEL} --official_build=true --skip_signing"
-                            }
-                        }
-                        stage("dist-release") {
-                            when {
-                                expression { "${RELEASE_TYPE}" == "release" }
-                            }
-                            steps {
-                                sh "npm run create_dist -- ${BUILD_TYPE} --channel=${CHANNEL} --official_build=true"
                             }
                         }
                         stage("archive") {
@@ -545,7 +574,7 @@ pipeline {
                                 }
                             }
                             steps {
-                                checkout([$class: 'GitSCM', branches: [[name: "${BRANCH_TO_BUILD}"]], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/brave/brave-browser.git']]])
+                                checkout([$class: "GitSCM", branches: [[name: "${BRANCH_TO_BUILD}"]], extensions: [[$class: "WipeWorkspace"]], userRemoteConfigs: [[url: "https://github.com/brave/brave-browser.git"]]])
                             }
                         }
                         stage("pin") {
@@ -554,7 +583,8 @@ pipeline {
                             }
                             steps {
                                 powershell """
-                                    \$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
+                                    \$ErrorActionPreference = "Stop"
+                                    \$PSDefaultParameterValues['Out-File:Encoding'] = "utf8"
                                     jq "del(.config.projects[\\`"brave-core\\`"].branch) | .config.projects[\\`"brave-core\\`"].branch=\\`"${BRANCH_TO_BUILD}\\`"" package.json > package.json.new
                                     Move-Item -Force package.json.new package.json
                                 """
@@ -562,8 +592,11 @@ pipeline {
                         }
                         stage("install") {
                             steps {
-                                powershell "npm install --no-optional"
-                                powershell "Remove-Item ${GIT_CACHE_PATH}/*.lock"
+                                powershell """
+                                    \$ErrorActionPreference = "Stop"
+                                    npm install --no-optional
+                                    Remove-Item -ErrorAction SilentlyContinue -Force ${GIT_CACHE_PATH}/*.lock
+                                """
                             }
                         }
                         stage("init") {
@@ -571,12 +604,18 @@ pipeline {
                                 expression { return !fileExists("src/brave/package.json") || RUN_INIT }
                             }
                             steps {
-                                powershell "npm run init"
+                                powershell """
+                                    \$ErrorActionPreference = "Stop"
+                                    npm run init
+                                """
                             }
                         }
                         stage("sync") {
                             steps {
-                                powershell "npm run sync -- --all"
+                                powershell """
+                                    \$ErrorActionPreference = "Stop"
+                                    npm run sync -- --all
+                                """
                             }
                         }
                         stage("lint") {
@@ -584,6 +623,7 @@ pipeline {
                                 script {
                                     try {
                                         powershell """
+                                            \$ErrorActionPreference = "Stop"
                                             git -C src/brave config user.name brave-builds
                                             git -C src/brave config user.email devops@brave.com
                                             git -C src/brave checkout -b ${LINT_BRANCH}
@@ -598,10 +638,28 @@ pipeline {
                                 }
                             }
                         }
+                        stage("audit-deps") {
+                            steps {
+                                timeout(time: 2, unit: "MINUTES") {
+                                    script {
+                                        try {
+                                            powershell """
+                                                \$ErrorActionPreference = "Stop"
+                                                npm run audit_deps
+                                            """
+                                        }
+                                        catch (ex) {
+                                            currentBuild.result = "UNSTABLE"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         // TODO: add sccache
                         stage("build") {
                             steps {
                                 powershell """
+                                    \$ErrorActionPreference = "Stop"
                                     npm config --userconfig=.npmrc set brave_referrals_api_key ${REFERRAL_API_KEY}
                                     npm config --userconfig=.npmrc set brave_google_api_endpoint https://location.services.mozilla.com/v1/geolocate?key=
                                     npm config --userconfig=.npmrc set brave_google_api_key ${BRAVE_GOOGLE_API_KEY}
@@ -611,26 +669,15 @@ pipeline {
                                 """
                             }
                         }
-                        stage("network-audit") {
+                        stage("audit-network") {
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     script {
                                         try {
-                                            powershell "npm run network-audit -- --output_path=\"${OUT_DIR}/brave.exe\""
-                                        }
-                                        catch (ex) {
-                                            currentBuild.result = "UNSTABLE"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        stage("audit_deps") {
-                            steps {
-                                timeout(time: 2, unit: "MINUTES") {
-                                    script {
-                                        try {
-                                            powershell "npm run audit_deps"
+                                            powershell """
+                                                \$ErrorActionPreference = "Stop"
+                                                npm run network-audit -- --output_path="${OUT_DIR}/brave.exe"
+                                            """
                                         }
                                         catch (ex) {
                                             currentBuild.result = "UNSTABLE"
@@ -655,30 +702,15 @@ pipeline {
                             }
                         }
                         // TODO: add test-browser
-                        stage("dist-ci") {
-                            when {
-                                expression { "${RELEASE_TYPE}" == "ci" }
-                            }
+                        stage("dist") {
                             steps {
                                 powershell """
-                                    Import-PfxCertificate -FilePath \"${KEY_PFX_PATH}\" -CertStoreLocation "Cert:\\LocalMachine\\My" -Password (ConvertTo-SecureString -String \"${AUTHENTICODE_PASSWORD_UNESCAPED}\" -AsPlaintext -Force)
+                                    \$ErrorActionPreference = "Stop"
+                                    Import-PfxCertificate -FilePath "${KEY_PFX_PATH}" -CertStoreLocation "Cert:\\LocalMachine\\My" -Password (ConvertTo-SecureString -String "${AUTHENTICODE_PASSWORD_UNESCAPED}" -AsPlaintext -Force)
                                     npm run create_dist -- ${BUILD_TYPE} --channel=${CHANNEL} --official_build=true --skip_signing
+                                    (Get-Content src/brave/vendor/omaha/omaha/hammer-brave.bat) | % { \$_ -replace "10.0.15063.0\\\\", "" } | Set-Content src/brave/vendor/omaha/omaha/hammer-brave.bat
+                                    npm run create_dist -- ${BUILD_TYPE} --channel=${CHANNEL} --build_omaha --tag_ap=x64-${CHANNEL} --target_arch=x64 --official_build=true --skip_signing
                                 """
-                                powershell '(Get-Content src\\brave\\vendor\\omaha\\omaha\\hammer-brave.bat) | % { $_ -replace "10.0.15063.0\", "" } | Set-Content src\\brave\\vendor\\omaha\\omaha\\hammer-brave.bat'
-                                powershell "npm run create_dist -- ${BUILD_TYPE} --channel=${CHANNEL} --build_omaha --tag_ap=x64-${CHANNEL} --target_arch=x64 --official_build=true --skip_signing"
-                            }
-                        }
-                        stage("dist-release") {
-                            when {
-                                expression { "${RELEASE_TYPE}" == "release" }
-                            }
-                            steps {
-                                powershell """
-                                    Import-PfxCertificate -FilePath \"${KEY_PFX_PATH}\" -CertStoreLocation "Cert:\\LocalMachine\\My" -Password (ConvertTo-SecureString -String \"${AUTHENTICODE_PASSWORD_UNESCAPED}\" -AsPlaintext -Force)
-                                    npm run create_dist -- ${BUILD_TYPE} --channel=${CHANNEL} --official_build=true
-                                """
-                                powershell '(Get-Content src\\brave\\vendor\\omaha\\omaha\\hammer-brave.bat) | % { $_ -replace "10.0.15063.0\", "" } | Set-Content src\\brave\\vendor\\omaha\\omaha\\hammer-brave.bat'
-                                powershell "npm run create_dist -- ${BUILD_TYPE} --channel=${CHANNEL} --build_omaha --tag_ap=x64-${CHANNEL} --target_arch=x64 --official_build=true"
                             }
                         }
                         stage("archive") {
@@ -711,4 +743,29 @@ pipeline {
             }
         }
     }
+    post {
+        always {
+            script {
+                if (env.SLACK_USERNAME) {
+                    def slackColorMap = ["SUCCESS": "good", "FAILURE": "danger", "UNSTABLE": "warning", "ABORTED": null]
+                    slackSend(color: slackColorMap[currentBuild.currentResult], channel: env.SLACK_USERNAME, message: currentBuild.currentResult + " - ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}/flowGraphTable/?auto_refresh=true|Open>)")
+                }
+            }
+        }
+    }
+}
+
+@NonCPS
+def stopCurrentBuild() {
+    Jenkins.instance.getItemByFullName(env.JOB_NAME).getLastBuild().doStop()
+}
+
+@NonCPS
+def isStartedManually() {
+    return Jenkins.instance.getItemByFullName(env.JOB_NAME).getLastBuild().getCause(hudson.model.Cause$UpstreamCause) == null
+}
+
+@NonCPS
+def getBuilds() {
+    return Jenkins.instance.getItemByFullName(env.JOB_NAME).builds
 }


### PR DESCRIPTION
Closes https://github.com/brave/brave-browser/issues/4481
Closes https://github.com/brave/brave-browser/issues/4482
Closes https://github.com/brave/brave-browser/issues/4485
Closes https://github.com/brave/brave-browser/issues/4486

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
