### PR TITLE
Issue 4457: Split test-security into audit_deps and network_audit for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,12 +262,26 @@ pipeline {
                                 """
                             }
                         }
-                        stage("test-security") {
+                        stage("network-audit") {
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     script {
                                         try {
-                                            sh "npm run test-security -- --output_path=\"${OUT_DIR}/brave\""
+                                            sh "npm run network-audit -- --output_path=\"${OUT_DIR}/brave\""
+                                        }
+                                        catch (ex) {
+                                            currentBuild.result = "UNSTABLE"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        stage("audit_deps") {
+                            steps {
+                                timeout(time: 2, unit: "MINUTES") {
+                                    script {
+                                        try {
+                                            sh "npm run audit_deps"
                                         }
                                         catch (ex) {
                                             currentBuild.result = "UNSTABLE"
@@ -414,12 +428,26 @@ pipeline {
                                 """
                             }
                         }
-                        stage("test-security") {
+                        stage("network-audit") {
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     script {
                                         try {
-                                            sh "npm run test-security -- --output_path=\"${OUT_DIR}/Brave\\ Browser\\ ${CHANNEL_CAPITALIZED}.app/Contents/MacOS/Brave\\ Browser\\ ${CHANNEL_CAPITALIZED}\""
+                                            sh "npm run network-audit -- --output_path=\"${OUT_DIR}/Brave\\ Browser\\ ${CHANNEL_CAPITALIZED}.app/Contents/MacOS/Brave\\ Browser\\ ${CHANNEL_CAPITALIZED}\""
+                                        }
+                                        catch (ex) {
+                                            currentBuild.result = "UNSTABLE"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        stage("audit_deps") {
+                            steps {
+                                timeout(time: 2, unit: "MINUTES") {
+                                    script {
+                                        try {
+                                            sh "npm run audit_deps"
                                         }
                                         catch (ex) {
                                             currentBuild.result = "UNSTABLE"
@@ -583,12 +611,26 @@ pipeline {
                                 """
                             }
                         }
-                        stage("test-security") {
+                        stage("network-audit") {
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     script {
                                         try {
-                                            powershell "npm run test-security -- --output_path=\"${OUT_DIR}/brave.exe\""
+                                            powershell "npm run network-audit -- --output_path=\"${OUT_DIR}/brave.exe\""
+                                        }
+                                        catch (ex) {
+                                            currentBuild.result = "UNSTABLE"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        stage("audit_deps") {
+                            steps {
+                                timeout(time: 2, unit: "MINUTES") {
+                                    script {
+                                        try {
+                                            powershell "npm run audit_deps"
                                         }
                                         catch (ex) {
                                             currentBuild.result = "UNSTABLE"


### PR DESCRIPTION
fix #4457 

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

Check if CI has two stages `audit-deps` and `network-audit` instead of `test-security` 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
