### PR TITLE
Issue 4283: Disabling field trials 

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -64,6 +64,7 @@ Config.prototype.buildArgs = function () {
   const chrome_version_parts = this.chromeVersion.split('.')
 
   let args = {
+    fieldtrial_testing_like_official_build: true,
     safe_browsing_mode: 1,
     root_extra_deps: ["//brave"],
     // TODO: Re-enable when chromium_src overrides work for files in relative

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       },
       "brave-core": {
         "dir": "src/brave",
-        "branch": "master",
+        "branch": "disable_field_trials",
         "repository": {
           "url": "https://github.com/brave/brave-core.git"
         }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       },
       "brave-core": {
         "dir": "src/brave",
-        "branch": "disable_field_trials",
+        "branch": "master",
         "repository": {
           "url": "https://github.com/brave/brave-core.git"
         }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/4283

PR builder passed: https://staging.ci.brave.com/job/brave-browser-build-pr/job/PR-4551/24/

## Description

This PR disables field trials in Brave by setting `fieldtrial_testing_like_official_build` in config.js. 

The follow-up PR: https://github.com/brave/brave-core/pull/2471 :

1. Adds test for disabling field trials
2. Resets security indicator to display locks instead of security chips for EV certs (to match the behavior in current release builds)
3. Removes features that were disabled in brave_main_delegate.cc to override field trials

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [x] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

1. Navigate to brave://version and verify that only one variation is enabled
```
Variations | HideShortcutsOnNtp:HideShortcutsExperiment
```

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
