### PR TITLE
Upgrade from Chromium 75.0.3770.75 to Chromium 75.0.3770.80 (Uplift to 0.65.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "75.0.3770.75",
+        "tag": "75.0.3770.80",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },


### PR DESCRIPTION
Related https://github.com/brave/brave-core/pull/2599
Uplift of https://github.com/brave/brave-browser/pull/4718
Fixes https://github.com/brave/brave-browser/issues/4724
