### PR TITLE
Add support for running iOS unit tests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -34,17 +34,24 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
 
   // Build the tests
   util.run('ninja', ['-C', config.outputDir, suite], config.defaultOptions)
-  util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name"], config.defaultOptions)
-
-  let testBinary;
-  if (process.platform === 'win32') {
-    testBinary = `${suite}.exe`
+  if (config.targetOS === 'ios') {
+    util.run(path.join(config.outputDir, "iossim"), [
+      path.join(config.outputDir, `${suite}.app`),
+      path.join(config.outputDir, `${suite}.app/PlugIns/${suite}_module.xctest`)
+    ], config.defaultOptions)
   } else {
-    testBinary = suite
-  }
+    util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name"], config.defaultOptions)
 
-  // Run the tests
-  util.run(path.join(config.outputDir, testBinary), braveArgs, config.defaultOptions)
+    let testBinary;
+    if (process.platform === 'win32') {
+      testBinary = `${suite}.exe`
+    } else {
+      testBinary = suite
+    }
+
+    // Run the tests
+    util.run(path.join(config.outputDir, testBinary), braveArgs, config.defaultOptions)
+  }
 }
 
 module.exports = test


### PR DESCRIPTION
Adds ability to run unit tests for iOS using `npm run test brave_rewards_ios_tests -- --target_os=ios`

resolves #4812 

~https://github.com/brave/brave-core/pull/2667 should be merged first~

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] iOS
  - [x] Windows
  - [x] macOS
  - [x] Linux
- Verified that these changes pass automated tests (`npm test brave_unit_tests && npm test brave_browser_tests && npm run test-security`) on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.