### PR TITLE
Fix wrong src directory for widevine sig file generation on Windows

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -298,7 +298,7 @@ const util = {
       return
     }
 
-     if (process.env.CERT === undefined || process.env.SIGNTOOL_ARGS === undefined) {
+    if (process.env.CERT === undefined || process.env.SIGNTOOL_ARGS === undefined) {
       console.log('binary signing is skipped because of missing env vars')
       return
     }
@@ -311,7 +311,7 @@ const util = {
     if (!fs.existsSync(dir))
       fs.mkdirSync(dir);
 
-     fs.copySync(path.join(config.outputDir, 'brave.exe'), path.join(dir, 'brave.exe'));
+    fs.copySync(path.join(config.outputDir, 'brave.exe'), path.join(dir, 'brave.exe'));
     fs.copySync(path.join(config.outputDir, 'chrome.dll'), path.join(dir, 'chrome.dll'));
     fs.copySync(path.join(config.outputDir, 'chrome_child.dll'), path.join(dir, 'chrome_child.dll'));
 
@@ -319,22 +319,25 @@ const util = {
     util.run('python', [path.join(core_dir, 'script', 'sign_binaries.py'), '--build_dir=' + dir])
   },
 
-   generateWidevineSigFiles: () => {
+  generateWidevineSigFiles: () => {
     const cert = config.sign_widevine_cert
     const key = config.sign_widevine_key
     const passwd = config.sign_widevine_passwd
     const sig_generator = config.signature_generator
-    const src_dir = path.join(config.outputDir, 'signed_binaries')
+    let src_dir = path.join(config.outputDir, 'signed_binaries')
 
-     console.log('generate Widevine sig files...')
+    if (config.skip_signing || process.env.CERT === undefined || process.env.SIGNTOOL_ARGS === undefined)
+      src_dir = config.outputDir
 
-     util.run('python', [sig_generator, '--input_file=' + path.join(src_dir, 'brave.exe'),
+    console.log('generate Widevine sig files...')
+
+    util.run('python', [sig_generator, '--input_file=' + path.join(src_dir, 'brave.exe'),
         '--flags=1',
         '--certificate=' + cert,
         '--private_key=' + key,
         '--output_file=' + path.join(config.outputDir, 'brave.exe.sig'),
         '--private_key_passphrase=' + passwd])
-   util.run('python', [sig_generator, '--input_file=' + path.join(src_dir, 'chrome.dll'),
+    util.run('python', [sig_generator, '--input_file=' + path.join(src_dir, 'chrome.dll'),
         '--flags=0',
         '--certificate=' + cert,
         '--private_key=' + key,


### PR DESCRIPTION
When signing is skipped on Windows, source directory should be output dir.
When signing is enabled, source bin files are located in different dir.

Fix https://github.com/brave/brave-browser/issues/4875

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
