### PR TITLE
Revert "Enable widevine vmp on MacOS"

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -360,6 +360,10 @@ Config.prototype.update = function (options) {
         this.sign_widevine_cert !== "" && this.sign_widevine_key !== "" &&
         this.sign_widevine_passwd !== "" && fs.existsSync(this.signature_generator)
 
+    if (process.platform === 'darwin') {
+      this.brave_enable_cdm_host_verification = false
+    }
+
     if (this.brave_enable_cdm_host_verification) {
       console.log('Widevine cdm host verification is enabled')
     } else {


### PR DESCRIPTION
Reverts brave/brave-browser#4912

Reason: 
<img width="456" alt="Screen Shot 2019-06-14 at 11 41 34 PM" src="https://user-images.githubusercontent.com/6786187/59517746-334d0100-8eff-11e9-8e8f-7caf45e69e7b.png">
