### PR TITLE
Widevine 4.10.1440.18 is ready to use on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
       }
     },
     "widevine": {
-      "version": "4.10.1196.0"
+      "version": "4.10.1440.18"
     }
   },
   "repository": {


### PR DESCRIPTION
Update widevine version string to `4.10.1440.18` in package.json

Fix https://github.com/brave/brave-browser/issues/5022

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
1. Debug build after updating widevine version string in `package.json`
2. Start browser (`yarn start --vmodule=*widevine*=2`) with existing profile (widevine is already installed) and check below logs
```
[18294:18294:0624/064937.097475:VERBOSE1:brave_widevine_bundle_manager.cc(287)] StartupCheck: widevine prefs state looks fine
[18294:18294:0624/064937.097561:VERBOSE1:brave_widevine_bundle_manager.cc(288)] StartupCheck: installed widevine version: 4.10.1196.0
[18294:18294:0624/064937.097612:VERBOSE1:brave_widevine_bundle_manager.cc(292)] StartupCheck: new widevine version(4.10.1440.18) is found and background update is scheduled.
```
and updating log after 5mins (or immediately with `--fast-widevine-bundle-update` switch)
```
[18294:18294:0624/065437.098859:VERBOSE1:brave_widevine_bundle_manager.cc(337)] DoDelayedBackgroundUpdate: update widevine from 4.10.1196.0 to 4.10.1440.18
[18294:18294:0624/065437.098932:VERBOSE1:brave_widevine_bundle_manager.cc(108)] InstallWidevineBundle: Update widevine bundle
[18294:18294:0624/065437.098969:VERBOSE1:brave_widevine_bundle_manager.cc(219)] set_in_progress: 1
[18294:18294:0624/065438.987870:VERBOSE1:brave_widevine_bundle_manager.cc(160)] OnBundleDownloaded
[18294:18294:0624/065438.988132:VERBOSE1:brave_widevine_bundle_manager.cc(180)] OnGetTargetWidevineBundleDir
[18294:18294:0624/065438.988182:VERBOSE1:brave_widevine_bundle_unzipper.cc(62)] LoadFromZipFileInDir: zipped bundle file: /tmp/.org.chromium.Chromium.62DMd6
[18294:18294:0624/065438.988219:VERBOSE1:brave_widevine_bundle_unzipper.cc(63)] LoadFromZipFileInDir: target install dir: /home/simon/.config/BraveSoftware/Brave-Browser-Development/WidevineCdm
[18294:18294:0624/065438.988518:VERBOSE1:brave_widevine_bundle_unzipper.cc(87)] OnGetTempDirForUnzip: temp unzip dir: /tmp/.org.chromium.Chromium.EkiHFo
[18294:18294:0624/065439.069172:VERBOSE1:brave_widevine_bundle_manager.cc(207)] OnBundleUnzipped
[18294:18294:0624/065439.069250:VERBOSE1:brave_widevine_bundle_manager.cc(219)] set_in_progress: 0
[18294:18294:0624/065439.069283:VERBOSE1:brave_widevine_bundle_manager.cc(232)] set_needs_restart: 1
[18294:18294:0624/065439.069322:VERBOSE1:brave_widevine_bundle_manager.cc(325)] OnBackgroundUpdateFinished: Widevine update success
```
3. Restart and check below log (`yarn start --vmodule=*widevine*=2`)
```
[20432:20432:0624/065801.920133:VERBOSE1:brave_widevine_bundle_manager.cc(287)] StartupCheck: widevine prefs state looks fine
[20432:20432:0624/065801.920264:VERBOSE1:brave_widevine_bundle_manager.cc(288)] StartupCheck: installed widevine version: 4.10.1440.18
[20432:20432:0624/065801.920311:VERBOSE1:brave_widevine_bundle_manager.cc(301)] StartupCheck: latest widevine version is installed.
```

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
