### PR TITLE
Fix adblock-rust test path

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -41,6 +41,7 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
     ], config.defaultOptions)
   } else {
     util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name"], config.defaultOptions)
+    util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name_adblock"], config.defaultOptions)
 
     let testBinary;
     if (process.platform === 'win32') {


### PR DESCRIPTION
Fix brave/brave-browser#4793
Sister PR: https://github.com/brave/brave-core/pull/2569

There's a race condition if you try to use the same gn rule, so I had to make it separate.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Requested a security/privacy review as needed.
- [x] Public documentation has been updated as necessary. For instance:
  - [x] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
