### PR TITLE
Remove Identical Operand

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -261,7 +261,7 @@ const util = {
 #endif  // WIDEVINE_CDM_VERSION_H_`
 
     // If version file or fake lib file aren't existed, create them.
-    if (!fs.existsSync(widevineConfig.widevineCdmHeaderFilePath) {
+    if (!fs.existsSync(widevineConfig.widevineCdmHeaderFilePath) || !fs.existsSync(widevineConfig.fakeWidevineCdmLibFilePath)) {
       util.doPrepareWidevineCdmBuild(widevineConfig)
       return
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -261,8 +261,7 @@ const util = {
 #endif  // WIDEVINE_CDM_VERSION_H_`
 
     // If version file or fake lib file aren't existed, create them.
-    if (!fs.existsSync(widevineConfig.widevineCdmHeaderFilePath) ||
-        !fs.existsSync(widevineConfig.widevineCdmHeaderFilePath)) {
+    if (!fs.existsSync(widevineConfig.widevineCdmHeaderFilePath) {
       util.doPrepareWidevineCdmBuild(widevineConfig)
       return
     }


### PR DESCRIPTION
This fixes a [warning found by lgtm](https://lgtm.com/projects/g/brave/brave-browser/snapshot/49c71729b7002b76ad3cade9853fce2f7e1ed149/files/lib/util.js?sort=name&dir=ASC&mode=heatmap).
The same operand was used twice in an if statement.