### PR TITLE
Add --force_component_build option to `npm run build`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -60,6 +60,7 @@ const Config = function () {
   this.sign_widevine_key = process.env.SIGN_WIDEVINE_KEY || ''
   this.sign_widevine_passwd = process.env.SIGN_WIDEVINE_PASSPHRASE || ''
   this.signature_generator = path.join(this.srcDir, 'third_party', 'widevine', 'scripts', 'signature_generator.py') || ''
+  this.forceComponentBuild = false
 }
 
 Config.prototype.buildArgs = function () {
@@ -76,7 +77,7 @@ Config.prototype.buildArgs = function () {
     // TODO: Re-enable when chromium_src overrides work for files in relative
     // paths like widevine_cmdm_compoennt_installer.cc
     // use_jumbo_build: !this.officialBuild,
-    is_component_build: this.buildConfig !== 'Release',
+    is_component_build: this.forceComponentBuild || this.buildConfig !== 'Release',
     proprietary_codecs: true,
     ffmpeg_branding: "Chrome",
     enable_nacl: false,
@@ -401,6 +402,9 @@ Config.prototype.update = function (options) {
       this.xcode_gen_target = options.xcode_gen
     }
   }
+
+  if (options.force_component_build)
+    this.forceComponentBuild = true
 
   this.projectNames.forEach((projectName) => {
     // don't update refs for projects that have them

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -43,6 +43,7 @@ program
   .option('--ignore_compile_failure', 'Keep compiling regardless of error')
   .option('--skip_signing', 'skip signing binaries')
   .option('--xcode_gen <target>', 'Generate an Xcode workspace ("ios" or a list of semi-colon separated label patterns, run `gn help label_pattern` for more info.')
+  .option('--force_component_build', 'Link individual components instead of one big executable')
   .arguments('[build_config]')
   .action(build)
 


### PR DESCRIPTION
By default only debug builds use component mode. Allow using it with, e.g., release builds as well, for faster linking.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
