### PR TITLE
Add --gn and --ninja to npm run build

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,6 +16,19 @@ const getNPMConfig = (path) => {
     process.env[package_prefix + key]
 }
 
+const parseExtraInputs = (inputs, accumulator, callback) => {
+  for (let input of inputs) {
+    let separatorIndex = input.indexOf(':')
+    if (separatorIndex < 0) {
+      separatorIndex = input.length
+    }
+
+    const key = input.substring(0, separatorIndex);
+    const value = input.substring(separatorIndex + 1);
+    callback(accumulator, key, value)
+  }
+}
+
 const Config = function () {
   this.defaultBuildConfig = 'Debug'
   this.buildConfig = this.defaultBuildConfig
@@ -60,6 +73,8 @@ const Config = function () {
   this.sign_widevine_key = process.env.SIGN_WIDEVINE_KEY || ''
   this.sign_widevine_passwd = process.env.SIGN_WIDEVINE_PASSPHRASE || ''
   this.signature_generator = path.join(this.srcDir, 'third_party', 'widevine', 'scripts', 'signature_generator.py') || ''
+  this.extraGnArgs = {}
+  this.extraNinjaOpts = []
 }
 
 Config.prototype.buildArgs = function () {
@@ -102,6 +117,7 @@ Config.prototype.buildArgs = function () {
     brave_referrals_api_key: this.braveReferralsApiKey,
     enable_hangout_services_extension: this.enable_hangout_services_extension,
     enable_cdm_host_verification: this.brave_enable_cdm_host_verification,
+    ...this.extraGnArgs,
   }
 
   if (process.platform === 'darwin' && this.targetOS !== 'ios') {
@@ -400,6 +416,24 @@ Config.prototype.update = function (options) {
     } else {
       this.xcode_gen_target = options.xcode_gen
     }
+  }
+
+  if (options.gn) {
+    parseExtraInputs(options.gn, this.extraGnArgs, (args, key, value) => {
+      try {
+        value = JSON.parse(value)
+      } catch (e) {
+        // On parse error, leave value as string.
+      }
+      args[key] = value
+    })
+  }
+
+  if (options.ninja) {
+    parseExtraInputs(options.ninja, this.extraNinjaOpts, (opts, key, value) => {
+      opts.push(`-${key}`)
+      opts.push(value)
+    })
   }
 
   this.projectNames.forEach((projectName) => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -362,7 +362,13 @@ const util = {
 
     const args = util.buildArgsToString(config.buildArgs())
     util.run('gn', ['gen', config.outputDir, '--args="' + args + '"'], options)
-    util.run('ninja', ['-C', config.outputDir, config.buildTarget, '-k', num_compile_failure], options)
+
+    let ninjaOpts = [
+      '-C', config.outputDir, config.buildTarget,
+      '-k', num_compile_failure,
+      ...config.extraNinjaOpts
+    ]
+    util.run('ninja', ninjaOpts, options)
   },
 
   generateXcodeWorkspace: (options = config.defaultOptions) => {

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -18,6 +18,11 @@ const createDist = require('../lib/createDist')
 const upload = require('../lib/upload')
 const test = require('../lib/test')
 
+const collect = (value, accumulator) => {
+  accumulator.push(value)
+  return accumulator
+}
+
 const parsedArgs = program.parseOptions(process.argv)
 
 program
@@ -43,6 +48,8 @@ program
   .option('--ignore_compile_failure', 'Keep compiling regardless of error')
   .option('--skip_signing', 'skip signing binaries')
   .option('--xcode_gen <target>', 'Generate an Xcode workspace ("ios" or a list of semi-colon separated label patterns, run `gn help label_pattern` for more info.')
+  .option('--gn <arg>', 'Additional gn args, in the form <key>:<value>', collect, [])
+  .option('--ninja <opt>', 'Additional Ninja command-line options, in the form <key>:<value>', collect, [])
   .arguments('[build_config]')
   .action(build)
 


### PR DESCRIPTION
Use `--gn` to pass through ad-hoc gn args. `--gn=is_component_build:true` translates to `is_component_build=true`.

Use `--ninja` to add command line options for Ninja. `--ninja=j:48` translates to `-j 48`.

Fix https://github.com/brave/brave-browser/issues/5184

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
