### PR TITLE
Apply patches without considering whitespace / line-ending differences

### DIFF
--- a/lib/gitPatcher.js
+++ b/lib/gitPatcher.js
@@ -15,6 +15,7 @@ const encodingPatchInfo = 'utf8'
 // Increment schema version if we make breaking changes
 // to the Patch Info file format.
 const patchInfoSchemaVersion = 1
+const applyArgs = [ '--ignore-space-change', '--ignore-whitespace' ]
 
 const patchApplyReasons = {
   NO_PATCH_INFO: 0,
@@ -212,7 +213,7 @@ module.exports = class GitPatcher {
       const { patchPath } = patchData
       this.logProgress('.')
       try {
-        await util.runGitAsync(this.repoPath, ['apply', patchPath])
+        await util.runGitAsync(this.repoPath, ['apply', patchPath, ...applyArgs])
       } catch (err) {
         patchData.error = err
       }
@@ -252,7 +253,7 @@ module.exports = class GitPatcher {
   }
 
   async getAppliesTo (patchPath) {
-    const applyStatArgs = ['apply', patchPath, '--numstat', '-z']
+    const applyStatArgs = ['apply', patchPath, '--numstat', '-z', ...applyArgs]
     // Check which files patch applies to
     return ( await util.runGitAsync(this.repoPath, applyStatArgs) )
     .split(os.EOL)

--- a/lib/sync/logging.js
+++ b/lib/sync/logging.js
@@ -61,7 +61,7 @@ function logPatchStatus ({ reason, path, patchPath, error, warning }) {
   const success = !error
   const statusColor = success ? chalk.green : chalk.red
   console.log(statusColor.bold.underline(path || patchPath))
-  console.log(`  - Reason: ${GitPatcher.patchApplyReasonMessages[reason]}`)
+  console.log(`  - Patch applied because: ${GitPatcher.patchApplyReasonMessages[reason]}`)
   if (error) {
     console.log(chalk.red(`  - Error - ${error.message}`))
   }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5245

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
`npm run test:scripts`
`npm run sync -- --run_hooks`

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
