### PR TITLE
Fix #5275: Update whitelist patterns for new crlset request URLs

### DIFF
--- a/lib/whitelistedUrlPatterns.js
+++ b/lib/whitelistedUrlPatterns.js
@@ -1,7 +1,7 @@
 // Before adding to this list, get approval from the security team
 module.exports = [
-  'http://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
-  'https://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
+  'http://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+', // allowed because it 307's to crlsets.brave.com
+  'https://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+', // allowed because it 307's to crlsets.brave.com
   'http://www.google.com/dl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
   'https://www.google.com/dl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
   'http://storage.googleapis.com/update-delta/hfnkpimlhhgieaddgfemjhofmfblmnib/.+crxd', // allowed because it 307's to crlsets.brave.com,


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5275

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

`npm run network-audit` should test this change in CI. 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
