### PR TITLE
Add MacOS notarization

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -66,6 +66,8 @@ const Config = function () {
   this.mac_installer_signing_identifier = getNPMConfig(['mac_installer_signing_identifier']) || ''
   this.mac_signing_keychain = getNPMConfig(['mac_signing_keychain']) || 'login'
   this.mac_signing_output_prefix = 'signing'
+  this.notary_user = getNPMConfig(['notary_user']) || ''
+  this.notary_password = getNPMConfig(['notary_password']) || ''
   this.channel = ''
   this.sccache = getNPMConfig(['sccache'])
   this.braveReferralsApiKey = getNPMConfig(['brave_referrals_api_key']) || ''
@@ -134,6 +136,11 @@ Config.prototype.buildArgs = function () {
     args.mac_installer_signing_identifier = this.mac_installer_signing_identifier
     args.mac_signing_keychain = this.mac_signing_keychain
     args.mac_signing_output_prefix = this.mac_signing_output_prefix
+    if (this.notarize) {
+      args.notarize = true
+      args.notary_user = this.notary_user
+      args.notary_password = this.notary_password
+    }
   }
 
   if (process.platform === 'win32' && this.build_omaha) {
@@ -433,6 +440,9 @@ Config.prototype.update = function (options) {
 
   if (options.mac_signing_keychain)
     this.mac_signing_keychain = options.mac_signing_keychain
+
+  if (options.notarize)
+    this.notarize = true
 
   if (options.gclient_verbose)
     this.gClientVerbose = options.gclient_verbose

--- a/lib/createDist.js
+++ b/lib/createDist.js
@@ -7,6 +7,12 @@ const createDist = (buildConfig = config.defaultBuildConfig, options) => {
   config.buildConfig = buildConfig
   config.update(options)
 
+  if (config.notarize) {
+    notarize = config.notarize
+    notary_user = config.notary_user
+    notary_password = config.notary_password
+  }
+
   util.updateBranding()
   fs.removeSync(path.join(config.outputDir, 'dist'))
   config.buildTarget = 'create_dist'

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -73,6 +73,7 @@ program
   .option('--tag_ap <ap>', 'ap for stub/standalone installer')
   .option('--skip_signing', 'skip signing dmg/brave_installer.exe')
   .option('--brave_safetynet_api_key <brave_safetynet_api_key>')
+  .option('--notarize', 'notarize the macOS app with Apple')
   .arguments('[build_config]')
   .action(createDist)
 


### PR DESCRIPTION
Work in progress.

Depends upon changes in brave-core branch `issue_5177`.

Requires NPM configuration such as:
```
npm config --userconfig=.npmrc set notary_user APPLEID_EMAIL_ADDRESS
npm config --userconfig=.npmrc set notary_password APPLE_APP_SPECIFIC_PASSWORD
```

Fixes: https://github.com/brave/brave-browser/issues/5177
Related: https://github.com/brave/brave-core/pull/3725

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
