### PR TITLE
Upgrade from Chromium 76.0.3809.87 to Chromium 76.0.3809.100 (RELEASE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "76.0.3809.87",
+        "tag": "76.0.3809.100",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/5556
Related: https://github.com/brave/brave-core/pull/3108
Fixes https://github.com/brave/brave-browser/issues/5554

Approved, please ensure that before merging: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.