### PR TITLE
Add a note about Debian 9 gnutls bug

### DIFF
--- a/docs/source/installing-brave.rst
+++ b/docs/source/installing-brave.rst
@@ -31,6 +31,11 @@ Ubuntu 16.04+ and Mint 18+
 
 Debian 9, Ubuntu 14.04 and Mint 17
 ----------------------------------
+
+If you get ``gnutls_handshake()`` errors after adding the Brave repository on Debian 9,
+you may need to `uninstall old conflicting packages
+<https://github.com/signalapp/Signal-Desktop/issues/2483#issuecomment-401047201>`_.
+
 ::
 
     sudo apt install apt-transport-https


### PR DESCRIPTION
This was reported in https://twitter.com/datashed/status/1161402640330182657
and also affects other projects:

https://github.com/signalapp/Signal-Desktop/issues/2483
https://forum.openmediavault.org/index.php/Thread/25432-E-Failed-to-fetch-Public-key-signature-verification-failed/
https://stackoverflow.com/questions/39437606/curl-35-gnutls-handshake-failed-public-key-signature-verification-has-fail

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.