### PR TITLE
Add l10n support for ethereum-remote-client

### DIFF
--- a/lib/l10nUtil.js
+++ b/lib/l10nUtil.js
@@ -104,6 +104,11 @@ module.exports.allBravePaths = module.exports.braveNonGeneratedPaths.concat(modu
 // This is because only 1 xtb is created per grd per locale even if it has multiple grdp files.
 module.exports.braveTopLevelPaths = module.exports.allBravePaths.filter((x) => ['grd', 'json'].includes(x.split('.').pop()))
 
+// ethereum-remote-client path relative to the Brave paths
+module.exports.ethereumRemoteClientPaths = [
+  '../../../ethereum-remote-client/app/_locales/en/messages.json',
+  '../../../ethereum-remote-client/brave/app/_locales/en/messages.json'
+]
 
 // This simply reads Chromium files that are passed to it and replaces branding strings
 // with Brave specific branding strings.

--- a/lib/pullL10n.js
+++ b/lib/pullL10n.js
@@ -1,11 +1,22 @@
 const config = require('../lib/config')
 const util = require('../lib/util')
-const {braveTopLevelPaths} = require('./l10nUtil')
+const {braveTopLevelPaths, ethereumRemoteClientPaths} = require('./l10nUtil')
 
 const pullL10n = (options) => {
+  const cmdOptions = config.defaultOptions
+  cmdOptions.cwd = config.projects['brave-core'].dir
+  if (options.extension) {
+    if (options.extension === 'ethereum-remote-client') {
+      ethereumRemoteClientPaths.forEach((sourceStringPath) => {
+        util.run('python', ['script/pull-l10n.py', '--source_string_path', sourceStringPath], cmdOptions)
+      })
+      return
+    }
+    console.error('Unknown extension: ', options.extension)
+    process.exit(1)
+  }
+
   braveTopLevelPaths.forEach((sourceStringPath) => {
-    const cmdOptions = config.defaultOptions
-    cmdOptions.cwd = config.projects['brave-core'].dir
     util.run('python', ['script/pull-l10n.py', '--source_string_path', sourceStringPath], cmdOptions)
   })
 }

--- a/lib/pushL10n.js
+++ b/lib/pushL10n.js
@@ -1,20 +1,30 @@
 const config = require('../lib/config')
 const util = require('../lib/util')
-const {braveTopLevelPaths} = require('./l10nUtil')
+const {braveTopLevelPaths, ethereumRemoteClientPaths} = require('./l10nUtil')
 
 const pushL10n = (options) => {
-  // Get rid of local copied xtb and grd changes
   const runOptions = { cwd: config.projects.chrome.dir }
-  let args = ['checkout', '--', '*.xtb']
-  util.run('git', args, runOptions)
-  args = ['checkout', '--', '*.grd*']
-  util.run('git', args, runOptions)
-
-  braveTopLevelPaths.forEach((sourceStringPath) => {
-    const cmdOptions = config.defaultOptions
-    cmdOptions.cwd = config.projects['brave-core'].dir
-    util.run('python', ['script/push-l10n.py', '--source_string_path', sourceStringPath], cmdOptions)
-  })
+  const cmdOptions = config.defaultOptions
+  cmdOptions.cwd = config.projects['brave-core'].dir
+  if (options.extension) {
+    if (options.extension === 'ethereum-remote-client') {
+      ethereumRemoteClientPaths.forEach((sourceStringPath) => {
+        util.run('python', ['script/push-l10n.py', '--source_string_path', sourceStringPath], cmdOptions)
+      })
+      return
+    }
+    console.error('Unknown extension: ', options.extension)
+    process.exit(1)
+  } else {
+    // Get rid of local copied xtb and grd changes
+    let args = ['checkout', '--', '*.xtb']
+    util.run('git', args, runOptions)
+    args = ['checkout', '--', '*.grd*']
+    util.run('git', args, runOptions)
+    braveTopLevelPaths.forEach((sourceStringPath) => {
+      util.run('python', ['script/push-l10n.py', '--source_string_path', sourceStringPath], cmdOptions)
+    })
+  }
 }
 
 module.exports = pushL10n

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -108,10 +108,12 @@ program
 
 program
   .command('pull_l10n')
+  .option('--extension <extension>', 'Scope this command to localize a Brave extension such as ethereum-remote-client')
   .action(pullL10n)
 
 program
   .command('push_l10n')
+  .option('--extension <extension>', 'Scope this command to localize a Brave extension such as ethereum-remote-client')
   .action(pushL10n)
 
 program


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/5686

Documentation added here:
https://github.com/brave/brave-browser/wiki/Strings-and-Localization#localizing-extensions

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [x] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
