### PR TITLE
Upgrade from Chromium 76.0.3809.100 to Chromium 76.0.3809.132 (uplift to 0.69.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "76.0.3809.100",
+        "tag": "76.0.3809.132",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/5801

Uplift of https://github.com/brave/brave-browser/pull/5806
Related https://github.com/brave/brave-core/pull/3262

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.