### PR TITLE
CI: For PRs, don't sign builds so that build outputs can be used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         choice(name: "CHANNEL", choices: ["nightly", "dev", "beta", "release"], description: "")
         string(name: "SLACK_BUILDS_CHANNEL", defaultValue: "#build-downloads-bot", description: "The Slack channel to send the list of artifact download links to. Leave blank to skip sending the message.")
         booleanParam(name: "OFFICIAL_BUILD", defaultValue: true, description: "")
-        booleanParam(name: "SKIP_SIGNING", defaultValue: false, description: "")
+        booleanParam(name: "SKIP_SIGNING", defaultValue: true, description: "")
         booleanParam(name: "WIPE_WORKSPACE", defaultValue: false, description: "")
         booleanParam(name: "SKIP_INIT", defaultValue: false, description: "")
         booleanParam(name: "DISABLE_SCCACHE", defaultValue: false, description: "")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
     parameters {
         choice(name: "BUILD_TYPE", choices: ["Release", "Debug"], description: "")
-        choice(name: "CHANNEL", choices: ["nightly", "dev", "beta", "release"], description: "")
+        choice(name: "CHANNEL", choices: ["development", "nightly", "dev", "beta", "release"], description: "")
         string(name: "SLACK_BUILDS_CHANNEL", defaultValue: "#build-downloads-bot", description: "The Slack channel to send the list of artifact download links to. Leave blank to skip sending the message.")
         booleanParam(name: "OFFICIAL_BUILD", defaultValue: true, description: "")
         booleanParam(name: "SKIP_SIGNING", defaultValue: true, description: "")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1044,11 +1044,11 @@ def checkAndAbortBuild() {
 def sendSlackDownloadsNotification() {
     // Notify links to all the build files
     echo "Reading all uploaded files for slack notification..."
-    def files = s3FindFiles(bucket: BRAVE_ARTIFACTS_S3_BUCKET, path: BUILD_TAG_SLASHED)
+    def files = s3FindFiles(bucket: BRAVE_ARTIFACTS_S3_BUCKET, path: BUILD_TAG_SLASHED, glob: "**")
     def attachments = [ ]
     files.each { file ->
         echo "Found file: ${file.name}"
-        if (file.name != "build.txt") {
+        if (!file.directory && file.name != "build.txt") {
             attachments.add([
                 title: file.name,
                 title_link: "https://" + BRAVE_ARTIFACTS_S3_BUCKET + ".s3.amazonaws.com/" + BUILD_TAG_SLASHED + "/" + file.path

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1051,7 +1051,8 @@ def sendSlackDownloadsNotification() {
         if (!file.directory && file.name != "build.txt") {
             attachments.add([
                 title: file.name,
-                title_link: "https://" + BRAVE_ARTIFACTS_S3_BUCKET + ".s3.amazonaws.com/" + BUILD_TAG_SLASHED + "/" + file.path
+                title_link: "https://" + BRAVE_ARTIFACTS_S3_BUCKET + ".s3.amazonaws.com/" + BUILD_TAG_SLASHED + "/" + file.path,
+                footer: byteLengthToString(file.length)
             ])
         }
     }
@@ -1077,6 +1078,21 @@ def sendSlackDownloadsNotification() {
     } else {
         echo "Not sending message, no files found."
     }
+}
+
+def byteLengthToString = { long byteLength ->
+    long base = 1024L
+    int decimals = 2
+    String[] suffixes = ['b', 'Kb', 'Mb', 'Gb', 'Tb']
+	int suffixIndex = Math.log(byteLength)/Math.log(base) as Integer
+	suffixIndex = (
+        suffixIndex >= prefixes.size()
+        ? prefixes.size() - 1
+        : suffixIndex
+    )
+    String suffix = " ${suffixes[suffixIndex]}"
+	return Math.round((byteLength / base**i) * 10**decimals) / 10**decimals +
+        suffix
 }
 
 @NonCPS

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1091,18 +1091,9 @@ def getSlackMessageText () {
 }
 
 def byteLengthToString (long byteLength) {
-    long base = 1024L
-    int decimals = 2
-    String[] suffixes = ['b', 'Kb', 'Mb', 'Gb', 'Tb']
-	int suffixIndex = Math.log(byteLength)/Math.log(base) as Integer
-	suffixIndex = (
-        suffixIndex >= prefixes.size()
-        ? prefixes.size() - 1
-        : suffixIndex
-    )
-    String suffix = " ${suffixes[suffixIndex]}"
-	return Math.round((byteLength / base**i) * 10**decimals) / 10**decimals +
-        suffix
+    def base = 1048576L
+    def mbLength = (byteLength / base) as Double
+    return mbLength.round() + " Mb"
 }
 
 @NonCPS


### PR DESCRIPTION
Right now, the signing is not done correctly and the outputs cannot be run on macOS due to a codesign error

Fix https://github.com/brave/brave-browser/issues/5823

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
Run an output from this PR job from the CI system

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
