### PR TITLE
Replace android_default_version_name with android_override_version_name

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -48,7 +48,7 @@ const Config = function () {
   this.targetArch = 'x64'
   this.gypTargetArch = 'x64'
   this.targetApkBase ='classic'
-  this.androidDefaultVersionName = '0.0.0'  
+  this.androidOverrideVersionName = '0.0.0'
   this.officialBuild = true
   this.debugBuild = JSON.parse(getNPMConfig(['brave_debug_build']) || false)
   this.braveGoogleApiKey = getNPMConfig(['brave_google_api_key']) || 'AIzaSyAQfxPJiounkhOjODEO5ZieffeBv6yft2Q'
@@ -101,7 +101,7 @@ Config.prototype.buildArgs = function () {
     enable_widevine: true,
     target_cpu: this.targetArch,
     target_apk_base: this.targetApkBase,
-    android_default_version_name: this.androidDefaultVersionName,  
+    android_override_version_name: this.androidOverrideVersionName,
     is_official_build: this.officialBuild,
     is_debug: this.buildConfig !== 'Release',
     dcheck_always_on: this.buildConfig !== 'Release',
@@ -191,7 +191,7 @@ Config.prototype.buildArgs = function () {
     delete args.brave_infura_project_id
   } else {
     // This does not exist on non-Android platforms
-    delete args.android_default_version_name
+    delete args.android_override_version_name
   }
 
   if (this.targetOS === 'ios') {
@@ -334,8 +334,8 @@ Config.prototype.update = function (options) {
     if (options.target_apk_base) {
       this.targetApkBase = options.target_apk_base
     }
-    if (options.android_default_version_name) {
-      this.androidDefaultVersionName = options.android_default_version_name
+    if (options.android_override_version_name) {
+      this.androidOverrideVersionName = options.android_override_version_name
     }
   }
 

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -38,7 +38,7 @@ program
   .option('--target_os <target_os>', 'target OS')
   .option('--target_arch <target_arch>', 'target architecture', 'x64')
   .option('--target_apk_base <target_apk_base>', 'target Android OS apk (classic, modern, mono)', 'classic')
-  .option('--android_default_version_name <android_default_version_name>', 'Android version number')
+  .option('--android_override_version_name <android_override_version_name>', 'Android version number')
   .option('--mac_signing_identifier <id>', 'The identifier to use for signing')
   .option('--mac_signing_keychain <keychain>', 'The identifier to use for signing', 'login')
   .option('--debug_build <debug_build>', 'keep debugging symbols')


### PR DESCRIPTION
Related to #4820

@SergeyZhukovsky Now that we're using a `chromium_src` override to handle versioning (instead of patching), I needed to switch the build config to use `android_override_version_name` instead of `android_default_version_name`. Without this change, the version number wasn't being picked up.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

See steps in related issue.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
