### PR TITLE
Fixes lint script.

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -19,7 +19,6 @@ sys.path.append(os.path.realpath(os.path.join(scriptpath, "..", "vendor", "depot
 
 import git_cl
 import git_common
-import auth
 
 def main(args):
   """Runs cpplint on the current changelist."""
@@ -29,9 +28,7 @@ def main(args):
                     help='Comma-separated list of cpplint\'s category-filters')
   parser.add_option('--project_root')
   parser.add_option('--base_branch')
-  auth.add_auth_options(parser)
   options, args = parser.parse_args(args)
-  auth_config = auth.extract_auth_config_from_options(options)
 
   # Access to a protected member _XX of a client class
   # pylint: disable=protected-access
@@ -48,7 +45,7 @@ def main(args):
   previous_cwd = os.getcwd()
   os.chdir(settings.GetRoot())
   try:
-    cl = git_cl.Changelist(auth_config=auth_config)
+    cl = git_cl.Changelist()
     change = cl.GetChange(git_common.get_or_create_merge_base(cl.GetBranch(), options.base_branch), None)
     files = [f.LocalPath() for f in change.AffectedFiles()]
     if not files:


### PR DESCRIPTION
Fixes brave/brave-browser#5971

Removed auth_config from our script as we don't need to pass it to
devtools script any more.

The failure is due to devtools change:

commit	934836a6c5b1a3442db7f7197569fc1bbdcb8991	[log] [tgz]
author	Edward Lemur <ehmaldonado@chromium.org>	Mon Sep 09 20:16:54 2019
committer	Commit Bot <commit-bot@chromium.org>	Mon Sep 09 20:16:54 2019
tree	c6cb985aca378a2f816bb7d21a072394b1d4882a
parent	1e4d70d1dd0865b0ac824beccee70d3852705dd8 [diff]
git-cl: Remove unused auth configs.

auth_config is a Rietveld thing, so it's not necessary
in most of the code, except for triggering try bots.

Bug: 1001756
Change-Id: I0f243a297b05a43a61b052ba75c5886556e81b4e
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/1793018

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
