### PR TITLE
Add support for Android unittests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -8,9 +8,13 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
   config.update(options)
 
   const braveArgs = [
-    '--enable-logging',
-    '--v=' + options.v,
+    '--enable-logging'
   ]
+
+  // Android doesn't support --v
+  if (config.targetOS !== 'android') {
+    braveArgs.push('--v=' + options.v)
+  }
 
   if (options.filter) {
     braveArgs.push('--gtest_filter=' + options.filter)
@@ -35,7 +39,7 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
   // Build the tests
   util.run('ninja', ['-C', config.outputDir, suite], config.defaultOptions)
 
-  const run_brave_installer_unitests = suite === 'brave_unit_tests'
+  const run_brave_installer_unitests = suite === 'brave_unit_tests' && config.targetOS !== 'android'
   if (run_brave_installer_unitests) {
     util.run('ninja', ['-C', config.outputDir, 'brave_installer_unittests'], config.defaultOptions)
   }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/6138
Sister PR: https://github.com/brave/brave-core/pull/3514
Documentation added here: https://github.com/brave/brave-browser/wiki/Tests#android

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
