### PR TITLE
Fix 6434: Using vpython for lint

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -453,7 +453,7 @@ const util = {
     }
     let cmd_options = config.defaultOptions
     cmd_options.cwd = config.projects['brave-core'].dir
-    util.run('python', [path.join(config.rootDir, 'scripts', 'lint.py'),
+    util.run('vpython', [path.join(config.rootDir, 'scripts', 'lint.py'),
         '--project_root=' + config.srcDir,
         '--base_branch=' + options.base], cmd_options)
   },

--- a/scripts/.vpython
+++ b/scripts/.vpython
@@ -1,0 +1,15 @@
+python_version: "2.7"
+
+# Used by:
+#   auth.py
+#   git_cl.py
+wheel: <
+  name: "infra/python/wheels/httplib2-py2_py3"
+  version: "version:0.10.3"
+>
+# Used by:
+#   git_cl.py
+wheel: <
+  name: "infra/python/wheels/six-py2_py3"
+  version: "version:1.10.0"
+>

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env vpython
+# Copyright (c) 2019 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#!/usr/bin/env python
+#!/usr/bin/env vpython
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.


### PR DESCRIPTION
fixes https://github.com/brave/brave-browser/issues/6434

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

1. Uninstall httplib2 `pip uninstall httplib2`
2. Update package.json to checkout `httplib2_lint` in brave-core
3. run: `npm run init`
4. in brave-core: `git checkout -b TEMP_LINT`
5. run: `npm run lint` and verify one error shows up 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
