### PR TITLE
Add missing copyright symbol

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -524,7 +524,7 @@ pipeline {
                         }
                         stage("test-unit") {
                             steps {
-                                timeout(time: 20, unit: "MINUTES") {
+                                timeout(time: 30, unit: "MINUTES") {
                                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
                                         script {
                                             sh "npm run test -- brave_unit_tests ${BUILD_TYPE} --output brave_unit_tests.xml"
@@ -727,7 +727,7 @@ pipeline {
                         }
                         stage("test-unit") {
                             steps {
-                                timeout(time: 20, unit: "MINUTES") {
+                                timeout(time: 30, unit: "MINUTES") {
                                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
                                         powershell """
                                             \$ErrorActionPreference = "Stop"

--- a/lib/l10nUtil.js
+++ b/lib/l10nUtil.js
@@ -156,6 +156,7 @@ const defaultReplacements = [
   [/Google Chrome/g, 'Brave'],
   [/Chromium/g, 'Brave'],
   [/Chrome/g, 'Brave'],
+  [/Google LLC/g, 'Brave Software Inc'],
   [/Google/g, 'Brave'],
   [/You're incognito/g, 'This is a private window'],
   [/an incognito/g, 'a private'],
@@ -172,4 +173,5 @@ const defaultReplacements = [
   [/Bookmarks Bar\n/g, 'Bookmarks\n'],
   [/Bookmarks bar\n/g, 'Bookmarks\n'],
   [/bookmarks bar\n/g, 'bookmarks\n'],
+  [/Copyright <ph name="(YEAR|year)">/g, 'Copyright © <ph name="$1">'],
 ]


### PR DESCRIPTION
Fixes brave/brave-browser#4990. Re-generated files in https://github.com/brave/brave-core/pull/3832

This also fixes a "Brave LLC" string in the copyright notice.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

On Desktop, open `chrome://settings/help` and check that the copyright symbol (C) is present.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
