### PR TITLE
[Docs]: Added reference to contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ For other versions of our browser, please see:
 * iOS - [brave/brave-ios](https://github.com/brave/brave-ios)
 * Android - [brave/browser-android-tabs](https://github.com/brave/browser-android-tabs)
 
+## Contributing
+
+Please see the [contributing guidelines](./CONTRIBUTING.md)
+
 ## Community
 
 [Join the Q&A community](https://community.brave.com/) if you'd like to get more involved with Brave. You can [ask for help](https://community.brave.com/c/support-and-troubleshooting),


### PR DESCRIPTION
Added a reference to `contributing guidelines` which people might miss out if otherwise.