### PR TITLE
Map ToS and privacy URLs to Brave equivalents on Android

### DIFF
--- a/lib/l10nUtil.js
+++ b/lib/l10nUtil.js
@@ -247,4 +247,6 @@ const defaultReplacements = [
   [/Bookmarks bar\n/g, 'Bookmarks\n'],
   [/bookmarks bar\n/g, 'bookmarks\n'],
   [/Copyright <ph name="(YEAR|year)">/g, 'Copyright © <ph name="$1">'],
+  [/https:\/\/www.google.com\/.*\/chrome\/browser\/privacy\/eula_text.html/g, 'https://brave.com/terms_of_use'],
+  [/https:\/\/www.google.com\/.*\/chrome\/browser\/privacy\//g, 'https://brave.com/privacy_android'],
 ]


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/7681

Initial attempt at a fix was made to an auto-generated file, which means it will be wiped out after `npm run chromium_rebase_l10n`. This updates the l10n default replacements to perform the transformation instead.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
