### PR TITLE
Directories underscores in components/third_party

### DIFF
--- a/lib/licensing.js
+++ b/lib/licensing.js
@@ -12,8 +12,6 @@ const knownMissing = new Set([
   path.join('components', 'third_party', 'adblock', 'lists', 'adblock_dk'),
   // https://github.com/gfmaster/adblock-korea-contrib/issues/47
   path.join('components', 'third_party', 'adblock', 'lists', 'adblock-korea-contrib'),
-  // https://github.com/tcptomato/ROad-Block/issues/55
-  path.join('components', 'third_party', 'adblock', 'lists', 'road-block')
 ])
 
 const extractLicenseInfo = (directory) => {

--- a/lib/licensing.js
+++ b/lib/licensing.js
@@ -146,14 +146,14 @@ const licensing = {
     console.log('  - ' + adblockComponents.length + ' sub-components added in adblock/LICENSE')
 
     // Brave Local Data component
-    const braveLocalDataDir = path.join(braveComponentsThirdPartyDir, 'local-data')
+    const braveLocalDataDir = path.join(braveComponentsThirdPartyDir, 'local_data')
     const braveLocalDataListsDir = path.join(braveLocalDataDir, 'lists')
     let localDataPreamble = 'These licenses do not apply to any of the code shipped with the Brave Browser, but may apply to data files downloaded after installation for use with various Brave features. The Brave Browser and such data files are separate and independent works.'
 
     const localDataComponents = listSubComponents(braveLocalDataListsDir)
     let localDataLicense = generateExternalComponentLicenseFile(localDataPreamble, localDataComponents)
-    fs.writeFileSync(path.join(braveComponentsThirdPartyDir, 'local-data', 'LICENSE'), localDataLicense)
-    console.log('  - ' + localDataComponents.length + ' sub-components added in local-data/LICENSE')
+    fs.writeFileSync(path.join(braveComponentsThirdPartyDir, 'local_data', 'LICENSE'), localDataLicense)
+    console.log('  - ' + localDataComponents.length + ' sub-components added in local_data/LICENSE')
   }
 }
 


### PR DESCRIPTION
Fixes brave/brave-browser#7176.

Requires https://github.com/brave/brave-core/pull/4380.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

1. Open `brave://credits`.
2. Verify that the "Brave Local Data" entry is present and that the license text is there too.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
