### PR TITLE
Upgrade from Chromium 79.0.3945.117 to Chromium 79.0.3945.130 (uplift to 1.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "79.0.3945.117",
+        "tag": "79.0.3945.130",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },


### PR DESCRIPTION
Upgrade from Chromium 79.0.3945.117 to Chromium 79.0.3945.130

Uplift of https://github.com/brave/brave-browser/pull/7782
Fixes https://github.com/brave/brave-browser/issues/7781
Related https://github.com/brave/brave-core/pull/4386