### PR TITLE
Add config for Android developer options

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -80,6 +80,7 @@ const Config = function () {
   this.extraGnArgs = {}
   this.extraNinjaOpts = []
   this.braveSafetyNetApiKey = getNPMConfig(['brave_safetynet_api_key']) || ''
+  this.braveAndroidDeveloperOptionsCode = getNPMConfig(['brave_android_developer_options_code']) || ''
   this.braveAndroidKeystorePath = getNPMConfig(['brave_android_keystore_path'])
   this.braveAndroidKeystoreName = getNPMConfig(['brave_android_keystore_name'])
   this.braveAndroidKeystorePassword = getNPMConfig(['brave_android_keystore_password'])
@@ -236,6 +237,7 @@ Config.prototype.buildArgs = function () {
     args.target_apk_base = this.targetApkBase
     args.android_override_version_name = this.androidOverrideVersionName
 
+    args.brave_android_developer_options_code = this.braveAndroidDeveloperOptionsCode
     args.brave_safetynet_api_key = this.braveSafetyNetApiKey
     args.enable_widevine = false
 


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/7892

This is the config side of the fix, allowing us to set the developer options code via .npmrc and pass it to the build.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
