### PR TITLE
Changes to provide ‘npm run coverage’

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -1,0 +1,108 @@
+const config = require('../lib/config')
+const licensing = require('../lib/licensing')
+const util = require('../lib/util')
+const path = require('path')
+const fs = require('fs-extra')
+
+const touchOverriddenFiles = () => {
+  console.log('touch original files overridden by chromium_src...')
+
+  // Return true when original file of |file| should be touched.
+  const applyFileFilter = (file) => {
+    // Exclude test files
+    if (file.indexOf('browsertest') > -1 || file.indexOf('unittest') > -1) { return false }
+
+    // Only includes cc and h files.
+    const ext = path.extname(file)
+    if (ext !== '.cc' && ext !== '.h' && ext !== '.mm') { return false }
+
+    return true
+  }
+
+  const chromiumSrcDir = path.join(config.srcDir, 'brave', 'chromium_src')
+  var sourceFiles = util.walkSync(chromiumSrcDir, applyFileFilter)
+
+  // Touch original files by updating mtime.
+  const chromiumSrcDirLen = chromiumSrcDir.length
+  sourceFiles.forEach(chromiumSrcFile => {
+    var overriddenFile = path.join(config.srcDir, chromiumSrcFile.slice(chromiumSrcDirLen))
+    if (!fs.existsSync(overriddenFile)) {
+      // Try to check that original file is in gen dir.
+      overriddenFile = path.join(config.outputDir, 'gen', chromiumSrcFile.slice(chromiumSrcDirLen))
+    }
+
+    if (fs.existsSync(overriddenFile)) {
+      // If overriddenFile is older than file in chromium_src, touch it to trigger rebuild.
+      if (fs.statSync(chromiumSrcFile).mtimeMs - fs.statSync(overriddenFile).mtimeMs > 0) {
+        const date = new Date()
+        fs.utimesSync(overriddenFile, date, date)
+        console.log(overriddenFile + ' is touched.')
+      }
+    }
+  })
+}
+
+const touchOverriddenVectorIconFiles = () => {
+  console.log('touch original vector icon files overridden by brave/vector_icons...')
+
+  // Return true when original file of |file| should be touched.
+  const applyFileFilter = (file) => {
+    // Only includes icon files.
+    const ext = path.extname(file)
+    if (ext !== '.icon') { return false }
+    return true
+  }
+
+  const braveVectorIconsDir = path.join(config.srcDir, 'brave', 'vector_icons')
+  var braveVectorIconFiles = util.walkSync(braveVectorIconsDir, applyFileFilter)
+
+  // Touch original files by updating mtime.
+  const braveVectorIconsDirLen = braveVectorIconsDir.length
+  braveVectorIconFiles.forEach(braveVectorIconFile => {
+    var overriddenFile = path.join(config.srcDir, braveVectorIconFile.slice(braveVectorIconsDirLen))
+    if (fs.existsSync(overriddenFile)) {
+      // If overriddenFile is older than file in vector_icons, touch it to trigger rebuild.
+      if (fs.statSync(braveVectorIconFile).mtimeMs - fs.statSync(overriddenFile).mtimeMs > 0) {
+        const date = new Date()
+        fs.utimesSync(overriddenFile, date, date)
+        console.log(overriddenFile + ' is touched.')
+      }
+    }
+  })
+}
+
+/**
+ * Checks to make sure the src/chrome/VERSION matches brave-browser's package.json version
+ */
+const checkVersionsMatch = () => {
+  const srcChromeVersionDir = path.resolve(path.join(__dirname, '..', 'src', 'chrome', 'VERSION'))
+  const versionData = fs.readFileSync(srcChromeVersionDir, 'utf8')
+  const re = /MAJOR=(\d+)\s+MINOR=(\d+)\s+BUILD=(\d+)\s+PATCH=(\d+)/
+  const found = versionData.match(re)
+  const braveVersionFromChromeFile = `${found[2]}.${found[3]}.${found[4]}`
+  if (braveVersionFromChromeFile !== config.braveVersion) {
+    // Only a warning. The CI environment will choose to proceed or not within its own script.
+    console.warn(`Version files do not match!\nsrc/chrome/VERSION: ${braveVersionFromChromeFile}\nbrave-browser package.json version: ${config.braveVersion}`)
+  }
+}
+
+const coverage = (buildConfig = config.defaultBuildConfig, options) => {
+  config.buildConfig = buildConfig
+  config.update(options)
+  checkVersionsMatch()
+
+  touchOverriddenFiles()
+  touchOverriddenVectorIconFiles()
+  util.updateBranding()
+  if (buildConfig === 'Release') {
+    licensing.updateLicenses()
+  }
+
+  if (config.xcode_gen_target) {
+    util.generateXcodeWorkspace()
+  } else {
+    util.runCoverage()
+  }
+}
+
+module.exports = coverage

--- a/lib/util.js
+++ b/lib/util.js
@@ -454,6 +454,30 @@ const util = {
     ]
     util.run('ninja', ninjaOpts, options)
   },
+ 
+  runCoverage: (options = config.defaultOptions) => {
+    console.log('running coverage for ' + config.buildTarget + '...')
+
+    if (process.platform === 'win32') util.updateOmahaMidlFiles()
+    if (process.platform === 'linux') util.prepareWidevineCdmBuild()
+
+    const args = util.buildArgsToString(config.buildArgs())
+    // provide arg for COVERAGE_OUT_DIR
+    util.run('gn', ['gen',
+      'out/coverage', // make an arg - i.e. build with COVERAGE_OUT_DIR as 'out/COVERAGE_OUT_DIR/coverage'
+      '--args="' + args + ' use_clang_coverage=true dcheck_always_on=true"'], options)
+    // is_component_build=false - is recommended from Chromium, but may not be required (works without it)
+
+      util.run('python', [ 
+        'tools/code_coverage/coverage.py', 
+        "brave_unit_tests", // utilise config.buildTarget in case unit test targets are changed
+        "-b", "out/coverage", // build path from COVERAGE_OUT_DIR arg
+        "-o", "out/report", // build path from COVERAGE_OUT_DIR arg
+        "-c", "out/coverage/brave_unit_tests", // build path from COVERAGE_OUT_DIR arg 
+        "-f", "brave/vendor/bat-native-ads/", // pass as optional arg(s)
+        "-f", "brave/vendor/bat-native-ledger/" 
+      ], options)
+  },
 
   generateXcodeWorkspace: (options = config.defaultOptions) => {
     console.log('generating Xcode workspace for "' + config.xcode_gen_target + '"...')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint": "node ./scripts/commands.js lint",
     "test": "node ./scripts/commands.js test",
     "test:scripts": "jest lib scripts",
-    "test-security": "npm run audit_deps && node ./scripts/commands.js start --enable_brave_update --network_log --user_data_dir_name=brave-network-test"
+    "test-security": "npm run audit_deps && node ./scripts/commands.js start --enable_brave_update --network_log --user_data_dir_name=brave-network-test",
+    "coverage": "node ./scripts/commands.js coverage"
   },
   "config": {
     "projects": {

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -18,6 +18,7 @@ const l10nDeleteTranslations = require('../lib/l10nDeleteTranslations')
 const createDist = require('../lib/createDist')
 const upload = require('../lib/upload')
 const test = require('../lib/test')
+const coverage = require('../lib/coverage')
 
 const collect = (value, accumulator) => {
   accumulator.push(value)
@@ -173,6 +174,28 @@ program
   .command('lint')
   .option('--base <base branch>', 'set the destination branch for the PR')
   .action(util.lint)
+  
+program
+  .command('coverage')
+  .option('-C <build_dir>', 'build config (out/Debug, out/Release')
+  .option('--target_os <target_os>', 'target OS')
+  .option('--target_arch <target_arch>', 'target architecture')
+  .option('--target_apk_base <target_apk_base>', 'target Android OS apk (classic, modern, mono)', 'classic')
+  .option('--android_override_version_name <android_override_version_name>', 'Android version number')
+  .option('--mac_signing_identifier <id>', 'The identifier to use for signing')
+  .option('--mac_signing_keychain <keychain>', 'The identifier to use for signing', 'login')
+  .option('--brave_google_api_key <brave_google_api_key>')
+  .option('--brave_google_api_endpoint <brave_google_api_endpoint>')
+  .option('--brave_infura_project_id <brave_infura_project_id>')
+  .option('--channel <target_channel>', 'target channel to build', /^(beta|dev|nightly|release)$/i)
+  .option('--ignore_compile_failure', 'Keep compiling regardless of error')
+  .option('--skip_signing', 'skip signing binaries')
+  .option('--xcode_gen <target>', 'Generate an Xcode workspace ("ios" or a list of semi-colon separated label patterns, run `gn help label_pattern` for more info.')
+  .option('--gn <arg>', 'Additional gn args, in the form <key>:<value>', collect, [])
+  .option('--ninja <opt>', 'Additional Ninja command-line options, in the form <key>:<value>', collect, [])
+  .option('--brave_safetynet_api_key <brave_safetynet_api_key>')
+  .arguments('[build_config]')
+  .action(coverage)
 
 program
   .parse(process.argv)


### PR DESCRIPTION
DO NOT MERGE

This PR is just to show how to utilise [Chromium Coverage]m on Mac OSX (Mojave) (https://chromium.googlesource.com/chromium/src/+/master/docs/testing/code_coverage.md) within Brave. 

Warrants further discussion on how to incorporate it into dev usage, and CI/Automation with devops.

The following steps are needed, but are not production/devop platform final - we'd need to decide what/how best to fulfil the requirements.

### Steps to 'be able to' run Coverage

- Install `llvm-profdata` & `llvm-cov`
-- the install 'tool link' in Chromium's web page link didn't work for me, I obtained the full [LLVM](https://releases.llvm.org/9.0.0/clang%2bllvm-9.0.0-x86_64-darwin-apple.tar.xz) tools package from LLVM, and made sure the 'bin' folder was in my local PATH
- Add the downloaded llvm tools `bin` to PATH
-- may not be necessary if installed properly
- Add `src/third_party/depot_tools` to PATH
-- should already be required for Brave builds?… but I had to add it
- Set an `export LLVM_PROFILE_FILE='out/brave/report/brave_unit_tests.%4m.profraw'` to restrict the profiles as per Chromium's '[Step 2 Create Raw Profiles](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/code_coverage.md#step-2-create-raw-profiles)'
- Create `src/Libraries` 
-- Nb. These steps could/should be better handled, but it's what I did to get this working. You may also need to have built with `npm run build` to produce these dylib's
-- Locate and copy `libchallenge_bypass_ristretto.dylib` to `src/Libraries`
-- Locate and copy `libadblock.dylib` to `src/Libraries`

### Usage

`npm run coverage`

and fingers crossed, it should build `brave_unit_tests` and run coverage for the (temporarily) hardcoded folders cited in `util.js`

A link is given to the report index.html at the end of the analysis stage. For me, on an iMac Pro, this takes about 30-40 mins for a clean build.

The `-f` arguments within the `utils.js` step simply restrict the analysis to the given folders. Providing no filters runs across the whole `brave_unit_tests` target, and for me this took about an hour, and hit ~150GB storage space in total. 

### Suggestions

- As noted in comments in `util.js` - passing arguments instead of hardcoding, but otherwise it's fairly simple.
- I doubt we need a separate `coverage.js` but I'll leave that to devops/build guru's to decide :)
