### PR TITLE
Use team ownership for network-audit whitelist

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 lib/licensing.js @fmarier
 
 # Network auditor
-lib/whitelistedUrlPatterns.js @fmarier
-lib/whitelistedUrlPrefixes.js @fmarier
+lib/whitelistedUrlPatterns.js @brave/sec-team
+lib/whitelistedUrlPrefixes.js @brave/sec-team


### PR DESCRIPTION
According to https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax, we don't have to use individual code owners, we can also use a team, which is much better in this case.