### PR TITLE
Fix 7959: Add tor.bravesoftware.com to audit whitelist (1.3.x)

### DIFF
--- a/lib/whitelistedUrlPrefixes.js
+++ b/lib/whitelistedUrlPrefixes.js
@@ -28,5 +28,6 @@ module.exports = [
   'https://pdfjs.robwu.nl/logpdfjs', // allowed because it gets canceled in tracking protection
   'https://publishers-distro.basicattentiontoken.org/',
   'https://publishers-staging-distro.basicattentiontoken.org/',
-  'https://p3a.brave.com/'
+  'https://p3a.brave.com/',
+  'https://tor.bravesoftware.com/', // for fetching tor client updater component
 ]


### PR DESCRIPTION
Uplift for https://github.com/brave/brave-browser/pull/7960
Fixes #7959 