### PR TITLE
Add missing dnf-plugins-core package for Fedora installs

### DIFF
--- a/docs/source/installing-brave.rst
+++ b/docs/source/installing-brave.rst
@@ -36,6 +36,8 @@ Fedora 28+, CentOS/RHEL 8+
 --------------------------
 ::
 
+    sudo dnf install dnf-plugins-core
+
     sudo dnf config-manager --add-repo https://brave-browser-rpm-release.s3.brave.com/x86_64/
 
     sudo rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
@@ -77,6 +79,8 @@ Debian 9+, Ubuntu 14.04+ and Mint 17+
 Fedora 28+, CentOS/RHEL 8+
 --------------------------
 ::
+
+    sudo dnf install dnf-plugins-core
 
     sudo dnf config-manager --add-repo https://brave-browser-rpm-beta.s3.brave.com/x86_64/
 
@@ -120,6 +124,8 @@ Fedora 28+, CentOS/RHEL 8+
 --------------------------
 ::
 
+    sudo dnf install dnf-plugins-core
+
     sudo dnf config-manager --add-repo https://brave-browser-rpm-dev.s3.brave.com/x86_64/
 
     sudo rpm --import https://brave-browser-rpm-dev.s3.brave.com/brave-core-nightly.asc
@@ -161,6 +167,8 @@ Debian 9+, Ubuntu 14.04+ and Mint 17+
 Fedora 28+, CentOS/RHEL 8+
 --------------------------
 ::
+
+    sudo dnf install dnf-plugins-core
 
     sudo dnf config-manager --add-repo https://brave-browser-rpm-nightly.s3.brave.com/x86_64/
 


### PR DESCRIPTION
As of Fedora 31, this package is not necessarily installed in minimal images. Without it, a user will run into the following error trying to use `dnf config-manager`:

    No such command: config-manager. Please use /usr/bin/dnf --help
    It could be a DNF plugin command, try: "dnf install 'dnf-command(config-manager)'"

I tested that the package can be installed on Fedora 29 and CentOS 8 too.