### PR TITLE
Upgrade from Chromium 79.0.3945.117 to Chromium 80.0.3987.78 (1.4.x)

### DIFF
--- a/lib/l10nUtil.js
+++ b/lib/l10nUtil.js
@@ -27,8 +27,8 @@ const chromiumSettingsPartPath = path.resolve(path.join(srcDir, 'chrome', 'app',
 const braveSettingsPartPath = path.resolve(path.join(srcDir, 'brave', 'app', 'settings_brave_strings.grdp'))
 
 //Replace android strings.
-const androidChromeStringsPath = path.resolve(path.join(srcDir, 'chrome', 'android', 'java', 'strings', 'android_chrome_strings.grd'))
-const braveAndroidChromeStringsPath = path.resolve(path.join(srcDir, 'brave', 'android', 'java', 'strings', 'android_chrome_strings.grd'))
+const androidChromeStringsPath = path.resolve(path.join(srcDir, 'chrome', 'browser', 'ui', 'android', 'strings', 'android_chrome_strings.grd'))
+const braveAndroidChromeStringsPath = path.resolve(path.join(srcDir, 'brave', 'browser', 'ui', 'android', 'strings', 'android_chrome_strings.grd'))
 
 // component_chromium_strings.grd and any of its parts files that we track localization for in transifex
 // These map to brave/app/strings/components_chromium_strings*.xtb
@@ -56,7 +56,7 @@ const braveSpecificGeneratedResourcesPath = path.resolve(path.join(srcDir, 'brav
 const braveResourcesComponentsStringsPath = path.resolve(path.join(srcDir, 'brave', 'components', 'resources', 'brave_components_strings.grd'))
 const braveExtensionMessagesPath = path.resolve(path.join(srcDir, 'brave', 'components', 'brave_extension', 'extension', 'brave_extension', '_locales', 'en_US', 'messages.json'))
 const braveRewardsExtensionMessagesPath = path.resolve(path.join(srcDir, 'brave', 'components', 'brave_rewards', 'resources', 'extension', 'brave_rewards', '_locales', 'en_US', 'messages.json'))
-const braveAndroidBraveStringsPath = path.resolve(path.join(srcDir, 'brave', 'android', 'java', 'strings', 'android_brave_strings.grd'))
+const braveAndroidBraveStringsPath = path.resolve(path.join(srcDir, 'brave', 'browser', 'ui', 'android', 'strings', 'android_brave_strings.grd'))
 
 const srcGit = path.resolve(path.join(srcDir, '.git'))
 
@@ -85,7 +85,7 @@ function AddGrd(chromiumPath, bravePath, exclude = new Set()) {
   if (!fs.existsSync(chromiumPath)) {
     const err = new Error(`AddGrd: Error. File not found at path "${chromiumPath}"`)
     console.error(err)
-    throw err
+    return
   }
   const grdps = getGrdPartsFromGrd(chromiumPath)
   if (grdps.length) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -156,8 +156,8 @@ const util = {
     const chromeBrowserResourcesDir = path.join(config.srcDir, 'chrome', 'browser', 'resources')
     const braveBrowserResourcesDir = path.join(config.projects['brave-core'].dir, 'browser', 'resources')
     const braveAppVectorIconsDir = path.join(config.projects['brave-core'].dir, 'vector_icons', 'chrome', 'app')
-    const chromeAndroidJavaStringsTranslationsDir = path.join(config.srcDir, 'chrome', 'android', 'java', 'strings', 'translations')
-    const braveAndroidJavaStringsTranslationsDir = path.join(config.projects['brave-core'].dir, 'android', 'java', 'strings', 'translations')
+    const chromeAndroidJavaStringsTranslationsDir = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'strings', 'translations')
+    const braveAndroidJavaStringsTranslationsDir = path.join(config.projects['brave-core'].dir, 'browser', 'ui', 'android', 'strings', 'translations')
 
     let fileMap = new Set();
     // The following 3 entries we map to the same name, not the chromium equivalent name for copying back
@@ -171,7 +171,7 @@ const util = {
     // brave/app/resources/chromium_strings*.xtb
     // brave/app/resources/generated_resoruces*.xtb
     // brave/components/strings/components_chromium_strings*.xtb
-    // brave/android/java/strings/translations/android_chrome_strings*.xtb
+    // brave/browser/ui/android/strings/translations/android_chrome_strings*.xtb
     fileMap.add([path.join(braveAppDir, 'resources'), path.join(chromeAppDir, 'resources')])
     fileMap.add([path.join(braveComponentsDir, 'strings'), path.join(chromeComponentsDir, 'strings')])
     fileMap.add([braveAndroidJavaStringsTranslationsDir, chromeAndroidJavaStringsTranslationsDir])
@@ -392,7 +392,6 @@ const util = {
 
     fs.copySync(path.join(config.outputDir, 'brave.exe'), path.join(dir, 'brave.exe'));
     fs.copySync(path.join(config.outputDir, 'chrome.dll'), path.join(dir, 'chrome.dll'));
-    fs.copySync(path.join(config.outputDir, 'chrome_child.dll'), path.join(dir, 'chrome_child.dll'));
 
      const core_dir = config.projects['brave-core'].dir
     util.run('python', [path.join(core_dir, 'script', 'sign_binaries.py'), '--build_dir=' + dir])
@@ -421,12 +420,6 @@ const util = {
         '--certificate=' + cert,
         '--private_key=' + key,
         '--output_file=' + path.join(config.outputDir, 'chrome.dll.sig'),
-        '--private_key_passphrase=' + passwd])
-    util.run('python', [sig_generator, '--input_file=' + path.join(src_dir, 'chrome_child.dll'),
-        '--flags=0',
-        '--certificate=' + cert,
-        '--private_key=' + key,
-        '--output_file=' + path.join(config.outputDir, 'chrome_child.dll.sig'),
         '--private_key_passphrase=' + passwd])
   },
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "79.0.3945.130",
+        "tag": "80.0.3987.66",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "80.0.3987.66",
+        "tag": "80.0.3987.78",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },


### PR DESCRIPTION
Fixes #7255
Fixes #7975
Related PR: brave/brave-core#4469

Uplift request from #7732

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
