### PR TITLE
Fixup some strings for google product names

### DIFF
--- a/lib/l10nUtil.js
+++ b/lib/l10nUtil.js
@@ -203,6 +203,9 @@ module.exports.rebaseBraveStringFilesOnChromiumL10nFiles = async function (path)
     for (const replacement of defaultReplacements) {
       contents = contents.replace(replacement[0], replacement[1])
     }
+    for (const replacement of fixupReplacements) {
+      contents = contents.replace(replacement[0], replacement[1])
+    }
     await new Promise(resolve => fs.writeFile(destPath, contents, 'utf8', resolve))
   })
   await Promise.all(ops)
@@ -230,7 +233,6 @@ const defaultReplacements = [
   [/Chrome/g, 'Brave'],
   [/Google LLC. All rights reserved./g, 'The Brave Authors. All rights reserved.'],
   [/(Google)(?! Play)/g, 'Brave'],
-  [/Brave Safe Browsing/g, 'Google Safe Browsing'],
   [/You're incognito/g, 'This is a private window'],
   [/an incognito/g, 'a private'],
   [/an Incognito/g, 'a Private'],
@@ -247,4 +249,13 @@ const defaultReplacements = [
   [/Bookmarks bar\n/g, 'Bookmarks\n'],
   [/bookmarks bar\n/g, 'bookmarks\n'],
   [/Copyright <ph name="(YEAR|year)">/g, 'Copyright © <ph name="$1">'],
+]
+
+// Fix up some strings after aggressive first round replacement.
+const fixupReplacements = [
+  [/Brave Cloud Print/g, 'Google Cloud Print'],
+  [/Brave Docs/g, 'Google Docs'],
+  [/Brave Drive/g, 'Google Drive'],
+  [/Brave OS/g, 'Chrome OS'],
+  [/Brave Safe Browsing/g, 'Google Safe Browsing'],
 ]


### PR DESCRIPTION
We should not replace google's own product name such as Google Docs
or Google Drive.

fix https://github.com/brave/brave-browser/issues/5450

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
