### PR TITLE
Auto-generate NTP backgrounds LICENSE file

### DIFF
--- a/lib/licensing.js
+++ b/lib/licensing.js
@@ -130,10 +130,56 @@ const listSubComponents = (baseDir) => {
   return subComponents
 }
 
+const listNtpBackgrounds = (metadataFile) => {
+  const metadata = fs.readFileSync(metadataFile).toString()
+  let images = []
+  // Hack to import this TypeScript file in Node:
+  eval(metadata.replace('export const images: NewTab.Image[]', 'images'))
+  return images
+}
+
+const getValidatedComponentField = (component, fieldName) => {
+    const fieldValue = component[fieldName]
+    if (!fieldValue) {
+       console.error('Missing' + fieldName + ' for background image ' + component['name'])
+       process.exit(1)
+    }
+    return fieldValue
+}
+
+const generateNtpBackgroundsLicense = (preamble, components) => {
+  let componentNotices = ''
+
+  for (let component of components) {
+    if (componentNotices.length != 0) {
+      componentNotices += '\n'
+    }
+
+    const fileName = getValidatedComponentField(component, 'source')
+    const authorName = getValidatedComponentField(component, 'author')
+    const authorLink = getValidatedComponentField(component, 'link')
+    const originalUrl = getValidatedComponentField(component, 'originalUrl')
+    const license = getValidatedComponentField(component, 'license')
+    if ((license != 'used with permission') &&
+        (license.substr(0, 8) != 'https://') && (license.substr(0, 7) != 'http://')) {
+      console.error('Invalid license for background image ' + component['name'] + '. It needs to be a URL or the string "used with permission".')
+      process.exit(1)
+    }
+
+    componentNotices += 'File: ' + fileName + '\n' +
+                        'Author: ' + authorName + ' (' + authorLink + ')\n' +
+                        'URL: ' + originalUrl + '\n' +
+                        'License: ' + license + '\n'
+  }
+
+  return preamble + '\n\n' + componentNotices
+}
+
 const licensing = {
   updateLicenses: () => {
     console.log('regenerating LICENSE files...')
-    const braveComponentsThirdPartyDir = path.join(config.projects['brave-core'].dir, 'components', 'third_party')
+    const braveComponentsDir = path.join(config.projects['brave-core'].dir, 'components')
+    const braveComponentsThirdPartyDir = path.join(braveComponentsDir, 'third_party')
 
     // Brave Ad Block component
     const braveAdBlockDir = path.join(braveComponentsThirdPartyDir, 'adblock')
@@ -154,6 +200,13 @@ const licensing = {
     let localDataLicense = generateExternalComponentLicenseFile(localDataPreamble, localDataComponents)
     fs.writeFileSync(path.join(braveComponentsThirdPartyDir, 'local_data', 'LICENSE'), localDataLicense)
     console.log('  - ' + localDataComponents.length + ' sub-components added in local_data/LICENSE')
+
+    const braveNtpDataDir = path.join(braveComponentsDir, 'brave_new_tab_ui', 'data')
+    let ntpBackgroundsPreamble = 'These licenses do not apply to any of the code shipped with the Brave Browser and instead apply to background images used on the new tab page. The Brave Browser and such data files are separate and independent works.'
+    const ntpBackgrounds = listNtpBackgrounds(path.join(braveNtpDataDir, 'backgrounds.ts'))
+    let ntpBackgroundsLicense = generateNtpBackgroundsLicense(ntpBackgroundsPreamble, ntpBackgrounds)
+    fs.writeFileSync(path.join(braveNtpDataDir, 'LICENSE'), ntpBackgroundsLicense)
+    console.log('  - ' + ntpBackgrounds.length + ' sub-components added in brave_new_tab_ui/data/LICENSE')
   }
 }
 


### PR DESCRIPTION
Fixes brave/brave-browser#7460 along with https://github.com/brave/brave-core/pull/4481.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

`npm run build Release`

Look at the "Background images" entry in `brave://credits`. It should contain URLs and licenses for all 16 background images.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
