### PR TITLE
Fix 8034: Add Crowd Deny requests to audit whitelist

### DIFF
--- a/lib/whitelistedUrlPatterns.js
+++ b/lib/whitelistedUrlPatterns.js
@@ -1,7 +1,7 @@
 // Before adding to this list, get approval from the security team
 module.exports = [
-  'http://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+', // allowed because it 307's to crlsets.brave.com
-  'https://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/chrome_component/.+', // allowed because it 307's to crlsets.brave.com
+  'http://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/.+', // allowed because it 307's to redirector.brave.com
+  'https://[A-Za-z0-9-\.]+\.gvt1\.com/edgedl/release2/.+', // allowed because it 307's to redirector.brave.com
   'http://www.google.com/dl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
   'https://www.google.com/dl/release2/chrome_component/.+crl-set.+', // allowed because it 307's to crlsets.brave.com
   'http://storage.googleapis.com/update-delta/hfnkpimlhhgieaddgfemjhofmfblmnib/.+crxd', // allowed because it 307's to crlsets.brave.com,

--- a/lib/whitelistedUrlPrefixes.js
+++ b/lib/whitelistedUrlPrefixes.js
@@ -4,8 +4,8 @@ module.exports = [
   'https://update.googleapis.com/service/update2', // allowed because it 307's to go-updater.brave.com. should never actually connect to googleapis.com.
   'https://safebrowsing.googleapis.com/v4/threatListUpdates', // allowed because it 307's to safebrowsing.brave.com
   'https://clients2.googleusercontent.com/crx/blobs/',
-  'http://dl.google.com/release2/chrome_component/', // allowed because it 307's to crlset1.brave.com
-  'https://dl.google.com/release2/chrome_component/', // allowed because it 307's to crlset1.brave.com
+  'http://dl.google.com/', // allowed because it 307's to redirector.brave.com
+  'https://dl.google.com/', // allowed because it 307's to redirector.brave.com
   'https://no-thanks.invalid/', // fake gaia URL
   'https://go-updater.brave.com/',
   'https://safebrowsing.brave.com/',
@@ -30,4 +30,5 @@ module.exports = [
   'https://dns.google/dns-query', // needed for DoH on Mac build machines
   'https://chrome.cloudflare-dns.com/dns-query', // needed for DoH on Mac build machines
   'https://tor.bravesoftware.com/', // for fetching tor client updater component
+  'https://redirector.brave.com/',
 ]


### PR DESCRIPTION
Fix #8034 
PR for proxy https://github.com/brave/brave-core/pull/4482

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
1. network-audit should pass.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
