### PR TITLE
added feature to run network audit on demand and disabled sccache on windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,9 +129,7 @@ pipeline {
                         }
                         stage("sccache") {
                             when {
-                                allOf {
-                                    expression { !DISABLE_SCCACHE }
-                                }
+                                expression { !DISABLE_SCCACHE }
                             }
                             steps {
                                 script {
@@ -351,9 +349,7 @@ pipeline {
                         }
                         stage("sccache") {
                             when {
-                                allOf {
-                                    expression { !DISABLE_SCCACHE }
-                                }
+                                expression { !DISABLE_SCCACHE }
                             }
                             steps {
                                 script {
@@ -370,6 +366,9 @@ pipeline {
                             }
                         }
                         stage("audit-network") {
+                            when {
+                                expression { RUN_NETWORK_AUDIT }
+                            }
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
@@ -497,9 +496,7 @@ pipeline {
                         }
                         stage("sccache") {
                             when {
-                                allOf {
-                                    expression { !DISABLE_SCCACHE }
-                                }
+                                expression { !DISABLE_SCCACHE }
                             }
                             steps {
                                 script {
@@ -520,6 +517,9 @@ pipeline {
                             }
                         }
                         stage("audit-network") {
+                            when {
+                                expression { RUN_NETWORK_AUDIT }
+                            }
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
@@ -687,18 +687,6 @@ pipeline {
                                 }
                             }
                         }
-                        stage("sccache") {
-                            when {
-                                allOf {
-                                    expression { !DISABLE_SCCACHE }
-                                }
-                            }
-                            steps {
-                                script {
-                                    sccacheWindows()
-                                }
-                            }
-                        }
                         stage("build") {
                             environment {
                                 SIGN_WIDEVINE_CERT = credentials("widevine_brave_prod_cert.der")
@@ -715,6 +703,9 @@ pipeline {
                             }
                         }
                         stage("audit-network") {
+                            when {
+                                expression { RUN_NETWORK_AUDIT }
+                            }
                             steps {
                                 timeout(time: 4, unit: "MINUTES") {
                                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
@@ -837,6 +828,7 @@ def setEnv() {
         SKIP_LINUX = bbPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-linux") }.equals(1)
         SKIP_MACOS = bbPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-macos") }.equals(1)
         SKIP_WINDOWS = bbPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-windows") }.equals(1)
+        RUN_NETWORK_AUDIT = bbPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/run-network-audit") }.equals(1)
         env.SLACK_USERNAME = readJSON(text: SLACK_USERNAME_MAP)[bbPrDetails.user.login]
         env.BRANCH_PRODUCTIVITY_HOMEPAGE = "https://github.com/brave/brave-browser/pull/${bbPrNumber}"
         env.BRANCH_PRODUCTIVITY_NAME = "Brave Browser PR #${bbPrNumber}"
@@ -856,6 +848,7 @@ def setEnv() {
             SKIP_LINUX = SKIP_LINUX || bcPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-linux") }.equals(1)
             SKIP_MACOS = SKIP_MACOS || bcPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-macos") }.equals(1)
             SKIP_WINDOWS = SKIP_WINDOWS || bcPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-windows") }.equals(1)
+            RUN_NETWORK_AUDIT = RUN_NETWORK_AUDIT || bcPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/run-network-audit") }.equals(1)
             env.SLACK_USERNAME = readJSON(text: SLACK_USERNAME_MAP)[bcPrDetails.user.login]
             env.BRANCH_PRODUCTIVITY_HOMEPAGE = "https://github.com/brave/brave-core/pull/${bcPrDetails.number}"
             env.BRANCH_PRODUCTIVITY_NAME = "Brave Core PR #${bcPrDetails.number}"
@@ -1022,14 +1015,6 @@ def lintWindows() {
 def sccache() {
     echo "Enabling sccache"
     sh "npm config --userconfig=.npmrc set sccache sccache"
-}
-
-def sccacheWindows() {
-    echo "Enabling sccache"
-    powershell """
-        \$ErrorActionPreference = "Stop"
-        npm config --userconfig=.npmrc set sccache sccache
-    """
 }
 
 def config() {


### PR DESCRIPTION
Closes https://github.com/brave/brave-browser/issues/8091

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [x] iOS
  - [x] Linux
  - [x] macOS
  - [x] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
