### PR TITLE
fixes an app icons in debug mode

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -282,16 +282,15 @@ const util = {
 
       // Mapping for copying Brave's Android resource into chromium folder.
       const copyAndroidResourceMapping = {
-        [androidIconSource]: androidIconDest,
-        [androidIconSource]: androidIconDestAdditional,
-        [androidResSource]: androidResDest,
-        [androidResNightSource]: androidResNightDest,
-        [androidNtpTilesResSource]: androidNtpTilesResDest,
-        [androidResTemplateSource]: androidResTemplateDest
+        [androidIconSource]: [androidIconDest, androidIconDestAdditional],
+        [androidResSource]: [androidResDest],
+        [androidResNightSource]: [androidResNightDest],
+        [androidNtpTilesResSource]: [androidNtpTilesResDest],
+        [androidResTemplateSource]: [androidResTemplateDest]
       }
 
       console.log('copy Android app icons and app resources')
-      Object.entries(copyAndroidResourceMapping).map(([sourcePath, destPath]) => {
+      Object.entries(copyAndroidResourceMapping).map(([sourcePath, destPaths]) => {
         let androidSourceFiles = []
         if (fs.statSync(sourcePath).isDirectory()) {
           androidSourceFiles = util.walkSync(sourcePath)
@@ -299,10 +298,12 @@ const util = {
           androidSourceFiles = [sourcePath]
         }
 
-        for (const androidSourceFile of androidSourceFiles) {
-          let destinationFile = path.join(destPath, path.relative(sourcePath, androidSourceFile))
-          if (!fs.existsSync(destinationFile) || util.calculateFileChecksum(androidSourceFile) != util.calculateFileChecksum(destinationFile)) {
-            fs.copySync(androidSourceFile, destinationFile)
+        for (const destPath of destPaths) {
+          for (const androidSourceFile of androidSourceFiles) {
+            let destinationFile = path.join(destPath, path.relative(sourcePath, androidSourceFile))
+            if (!fs.existsSync(destinationFile) || util.calculateFileChecksum(androidSourceFile) != util.calculateFileChecksum(destinationFile)) {
+              fs.copySync(androidSourceFile, destinationFile)
+            }
           }
         }
       })


### PR DESCRIPTION
Original issue is https://github.com/brave/brave-browser/issues/8023
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
