### PR TITLE
removed version mismatch check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ pipeline {
             steps {
                 sh "echo ${BUILD_URL} > build.txt"
                 s3Upload(bucket: BRAVE_ARTIFACTS_S3_BUCKET, path: BUILD_TAG_SLASHED, includePathPattern: "build.txt")
+                buildName env.BUILD_NUMBER + "-" + BRANCH + "-" + env.GIT_COMMIT.substring(0, 7)
             }
         }
         stage("build-all") {
@@ -432,7 +433,6 @@ pipeline {
                         stage("checkout") {
                             steps {
                                 checkout([$class: "GitSCM", branches: [[name: BRANCH]], extensions: [[$class: WIPE_WORKSPACE]], userRemoteConfigs: [[url: "https://github.com/brave/brave-browser.git"]]])
-                                buildName env.BUILD_NUMBER + "-" + BRANCH + "-" + env.GIT_COMMIT.substring(0, 7)
                             }
                         }
                         stage("pin") {
@@ -814,8 +814,8 @@ def setEnv() {
     if (env.CHANGE_BRANCH) {
         BRANCH = env.CHANGE_BRANCH
         BASE_BRANCH = env.CHANGE_TARGET
-        def bbPrNumber = readJSON(text: httpRequest(customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], url: GITHUB_API + "/brave-browser/pulls?head=brave:" + BRANCH, quiet: !DEBUG).content)[0].number
-        def bbPrDetails = readJSON(text: httpRequest(customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], url: GITHUB_API + "/brave-browser/pulls/" + bbPrNumber, quiet: !DEBUG).content)
+        def bbPrNumber = readJSON(text: httpRequest(url: GITHUB_API + "/brave-browser/pulls?head=brave:" + BRANCH, customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], quiet: !DEBUG).content)[0].number
+        def bbPrDetails = readJSON(text: httpRequest(url: GITHUB_API + "/brave-browser/pulls/" + bbPrNumber, customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], quiet: !DEBUG).content)
         SKIP = bbPrDetails.mergeable_state.equals("draft") || bbPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip") }.equals(1)
         SKIP_ANDROID = bbPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-android") }.equals(1)
         SKIP_IOS = bbPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-ios") }.equals(1)
@@ -829,12 +829,12 @@ def setEnv() {
         env.BRANCH_PRODUCTIVITY_DESCRIPTION = bbPrDetails.title
         env.BRANCH_PRODUCTIVITY_USER = env.SLACK_USERNAME ?: bbPrDetails.user.login
     }
-    BRANCH_EXISTS_IN_BC = httpRequest(customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], url: GITHUB_API + "/brave-core/branches/" + BRANCH, validResponseCodes: "100:499", quiet: !DEBUG).status.equals(200)
+    BRANCH_EXISTS_IN_BC = httpRequest(url: GITHUB_API + "/brave-core/branches/" + BRANCH, validResponseCodes: "100:499", customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], quiet: !DEBUG).status.equals(200)
     if (BRANCH_EXISTS_IN_BC) {
-        def bcPrDetails = readJSON(text: httpRequest(customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], url: GITHUB_API + "/brave-core/pulls?head=brave:" + BRANCH, quiet: !DEBUG).content)[0]
+        def bcPrDetails = readJSON(text: httpRequest(url: GITHUB_API + "/brave-core/pulls?head=brave:" + BRANCH, customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], quiet: !DEBUG).content)[0]
         if (bcPrDetails) {
             env.BC_PR_NUMBER = bcPrDetails.number
-            bcPrDetails = readJSON(text: httpRequest(customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], url: GITHUB_API + "/brave-core/pulls/" +  env.BC_PR_NUMBER, quiet: !DEBUG).content)
+            bcPrDetails = readJSON(text: httpRequest(url: GITHUB_API + "/brave-core/pulls/" +  env.BC_PR_NUMBER, customHeaders: [[name: "Authorization", value: "token ${PR_BUILDER_TOKEN}"]], quiet: !DEBUG).content)
             BASE_BRANCH = bcPrDetails.base.ref
             SKIP = bcPrDetails.mergeable_state.equals("draft") || bcPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip") }.equals(1)
             SKIP_ANDROID = SKIP_ANDROID || bcPrDetails.labels.count { label -> label.name.equalsIgnoreCase("CI/skip-android") }.equals(1)
@@ -873,18 +873,6 @@ def checkAndAbortBuild() {
             SKIP = true
             stopCurrentBuild()
         }
-    }
-    def bb_package_json = readJSON(text: httpRequest(url: "https://raw.githubusercontent.com/brave/brave-browser/" + BRANCH + "/package.json", quiet: !DEBUG).content)
-    def bb_version = bb_package_json.version
-    def bc_branch = bb_package_json.config.projects["brave-core"].branch
-    if (BRANCH_EXISTS_IN_BC) {
-        bc_branch = BRANCH
-    }
-    def bc_version = readJSON(text: httpRequest(url: "https://raw.githubusercontent.com/brave/brave-core/" + bc_branch + "/package.json", quiet: !DEBUG).content).version
-    if (bb_version != bc_version) {
-        echo "Version mismatch between brave-browser (" + BRANCH + "/" + bb_version + ") and brave-core (" + bc_branch + "/" + bc_version + ") in package.json"
-        SKIP = true
-        stopCurrentBuild()
     }
     if (!SKIP) {
         for (build in getBuilds()) {


### PR DESCRIPTION
Closes https://github.com/brave/brave-browser/issues/8260
Related https://github.com/brave/brave-core/pull/4658

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
