### PR TITLE
Move LICENSE file generation to create_dist (fixes #8618)

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,5 +1,4 @@
 const config = require('../lib/config')
-const licensing = require('../lib/licensing')
 const util = require('../lib/util')
 const path = require('path')
 const fs = require('fs-extra')
@@ -94,10 +93,6 @@ const build = (buildConfig = config.defaultBuildConfig, options) => {
   touchOverriddenFiles()
   touchOverriddenVectorIconFiles()
   util.updateBranding()
-  if (buildConfig === 'Release') {
-    // TODO(bsclifton): uncomment when we can address problem
-    // licensing.updateLicenses()
-  }
 
   if (config.xcode_gen_target) {
     util.generateXcodeWorkspace()

--- a/lib/createDist.js
+++ b/lib/createDist.js
@@ -1,4 +1,5 @@
 const config = require('../lib/config')
+const licensing = require('../lib/licensing')
 const util = require('../lib/util')
 const path = require('path')
 const fs = require('fs-extra')
@@ -14,6 +15,7 @@ const createDist = (buildConfig = config.defaultBuildConfig, options) => {
   }
 
   util.updateBranding()
+  licensing.updateLicenses()
   fs.removeSync(path.join(config.outputDir, 'dist'))
   config.buildTarget = 'create_dist'
   util.buildTarget()


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/8560.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

1. Go into `chrome://credits`.
2. Ensure that "Background images" is present and that its licensing info can be expanded.
3. Ensure that "Brave Ad Block" is present and that its licensing info can be expanded.

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
