### PR TITLE
Use safe_browsing_mode=2 for Android (Uplift to 1.5.x)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -240,6 +240,7 @@ Config.prototype.buildArgs = function () {
     args.brave_android_developer_options_code = this.braveAndroidDeveloperOptionsCode
     args.brave_safetynet_api_key = this.braveSafetyNetApiKey
     args.enable_widevine = false
+    args.safe_browsing_mode = 2
 
     // TODO(fixme)
     args.enable_tor = false
@@ -247,7 +248,6 @@ Config.prototype.buildArgs = function () {
 
     // These do not exist on android
     // TODO - recheck
-    delete args.safe_browsing_mode
     delete args.enable_nacl
     delete args.branding_path_component
     delete args.enable_hangout_services_extension


### PR DESCRIPTION
Uplift for PR https://github.com/brave/brave-browser/pull/8664

Fix #8381

please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
