### PR TITLE
don't copy java/res

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -270,10 +270,6 @@ const util = {
 
       const androidIconSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet)
       const androidIconDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium')
-      const androidResSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res')
-      const androidResDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res')
-      const androidResNightSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res_night')
-      const androidResNightDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_night')
       const androidNtpTilesResSource = path.join(config.projects['brave-core'].dir, 'components', 'ntp_tiles', 'resources')
       const androidNtpTilesResDest = path.join(config.srcDir, 'components', 'ntp_tiles', 'resources')
       const androidResTemplateSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res_template')
@@ -284,8 +280,6 @@ const util = {
       // Mapping for copying Brave's Android resource into chromium folder.
       const copyAndroidResourceMapping = {
         [androidIconSource]: [androidIconDest],
-        [androidResSource]: [androidResDest],
-        [androidResNightSource]: [androidResNightDest],
         [androidNtpTilesResSource]: [androidNtpTilesResDest],
         [androidResTemplateSource]: [androidResTemplateDest],
         [androidContentPublicResSource]: [androidContentPublicResDest]


### PR DESCRIPTION
Required for https://github.com/brave/brave-core/pull/5147

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
