### PR TITLE
don't copy ntp resources

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -309,8 +309,6 @@ const util = {
       const androidIconDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium')
       const androidResSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res')
       const androidResDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res')
-      const androidNtpTilesResSource = path.join(config.projects['brave-core'].dir, 'components', 'ntp_tiles', 'resources')
-      const androidNtpTilesResDest = path.join(config.srcDir, 'components', 'ntp_tiles', 'resources')
       const androidResTemplateSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res_template')
       const androidResTemplateDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_template')
       const androidContentPublicResSource = path.join(config.projects['brave-core'].dir, 'content', 'public', 'android', 'java', 'res')
@@ -320,7 +318,6 @@ const util = {
       const copyAndroidResourceMapping = {
         [androidIconSource]: [androidIconDest],
         [androidResSource]: [androidResDest],
-        [androidNtpTilesResSource]: [androidNtpTilesResDest],
         [androidResTemplateSource]: [androidResTemplateDest],
         [androidContentPublicResSource]: [androidContentPublicResDest]
       }


### PR DESCRIPTION
partial fix for https://github.com/brave/brave-browser/issues/9063
requires https://github.com/brave/brave-core/pull/5189

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
