### PR TITLE
Revert "don't copy java/res"

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -270,6 +270,10 @@ const util = {
 
       const androidIconSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet)
       const androidIconDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium')
+      const androidResSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res')
+      const androidResDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res')
+      const androidResNightSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res_night')
+      const androidResNightDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_night')
       const androidNtpTilesResSource = path.join(config.projects['brave-core'].dir, 'components', 'ntp_tiles', 'resources')
       const androidNtpTilesResDest = path.join(config.srcDir, 'components', 'ntp_tiles', 'resources')
       const androidResTemplateSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res_template')
@@ -280,6 +284,8 @@ const util = {
       // Mapping for copying Brave's Android resource into chromium folder.
       const copyAndroidResourceMapping = {
         [androidIconSource]: [androidIconDest],
+        [androidResSource]: [androidResDest],
+        [androidResNightSource]: [androidResNightDest],
         [androidNtpTilesResSource]: [androidNtpTilesResDest],
         [androidResTemplateSource]: [androidResTemplateDest],
         [androidContentPublicResSource]: [androidContentPublicResDest]


### PR DESCRIPTION
Reverts brave/brave-browser#8994

Reason: With this PR, NTP background images are not visible.