### PR TITLE
Upgrade from Chromium 81.0.4044.83 to Chromium 81.0.4044.92 (uplift to 1.8.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "81.0.4044.83",
+        "tag": "81.0.4044.92",
         "repository": {
           "url": "https://chromium.googlesource.com/chromium/src.git"
         },


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/9001
Fixing https://github.com/brave/brave-browser/issues/9000
Related https://github.com/brave/brave-core/pull/5190

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.