### PR TITLE
Revert "Remove GIT_CACHE_PATH temporarily to avoid remote inconsisten…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,7 @@ pipeline {
                     }
                     agent { label "android-ci" }
                     environment {
+                        GIT_CACHE_PATH = "${HOME}/cache"
                         QA_CODE = credentials("android-browser-qa-code")
                         KEYSTORE_NAME = "linkbubble"
                         KEYSTORE_PATH = credentials("android-browser-sign-key-store")
@@ -165,6 +166,9 @@ pipeline {
                         expression { !SKIP_IOS }
                     }
                     agent { label "mac-ci" }
+                    environment {
+                        GIT_CACHE_PATH = "${HOME}/cache"
+                    }
                     stages {
                         stage("checkout") {
                             steps {
@@ -257,6 +261,9 @@ pipeline {
                         expression { !SKIP_LINUX }
                     }
                     agent { label "linux-ci" }
+                    environment {
+                        GIT_CACHE_PATH = "${HOME}/cache"
+                    }
                     stages {
                         stage("checkout") {
                             steps {
@@ -383,6 +390,7 @@ pipeline {
                     }
                     agent { label "mac-ci" }
                     environment {
+                        GIT_CACHE_PATH = "${HOME}/cache"
                         KEYCHAIN = "signing-ci"
                         KEYCHAIN_PATH = "/Users/jenkins/Library/Keychains/${KEYCHAIN}.keychain-db"
                         KEYCHAIN_PASS = credentials("mac-ci-signing-keychain-password")
@@ -548,6 +556,7 @@ pipeline {
                         }
                     }
                     environment {
+                        GIT_CACHE_PATH = "C:\\Users\\Administrator\\cache"
                         PATH = "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.18362.0\\x64\\;C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\IDE\\Remote Debugger\\x64;${PATH}"
                         SIGNTOOL_ARGS = "sign /t http://timestamp.digicert.com /fd sha256 /sm"
                         CERT = "Brave"
@@ -910,6 +919,7 @@ def pinWindows() {
 
 def install() {
     sh """
+        rm -rf ${GIT_CACHE_PATH}/*.lock
         npm install --no-optional
     """
 }
@@ -973,6 +983,7 @@ def configWindows() {
 
 def installWindows() {
     powershell """
+        Remove-Item -Recurse -Force ${GIT_CACHE_PATH}/*.lock
         Get-ChildItem "Cert:\\LocalMachine\\My" | Remove-Item
         \$ErrorActionPreference = "Stop"
         npm install --no-optional


### PR DESCRIPTION
This reverts commit 8a70960b2a767c8fbed9f45ae3f2817805eaba5d.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
