### PR TITLE
If `src` remote hasn't been set yet, don't override with the Chromium repo

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -527,8 +527,11 @@ const util = {
   },
 
   gclientSync: (reset = false, options = {}) => {
+    const braveBrowserRemote = util.run('git', ['config', '--get', 'remote.origin.url']).stdout.toString().trim()
+    const srcRemote = util.run('git', ['-C', config.srcDir, 'config', '--get', 'remote.origin.url']).stdout.toString().trim()
     if (fs.existsSync(config.srcDir) &&
-        util.run('git', ['-C', config.srcDir, 'config', '--get', 'remote.origin.url']).stdout.toString().trim() != config.chromiumRepo) {
+      srcRemote != braveBrowserRemote &&
+      srcRemote != config.chromiumRepo) {
       console.log('setting src remote `origin` to ' + config.chromiumRepo)
       util.run('git', ['-C', config.srcDir, 'remote', 'remove', 'origin'], options)
       util.run('git', ['-C', config.srcDir, 'remote', 'add', 'origin', config.chromiumRepo], options)


### PR DESCRIPTION
Before `src` is initialized as a git repo, it inherits the remote from the parent folder

Fixes https://github.com/brave/brave-browser/issues/9308

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
1. Do fresh clone
2. Run `npm run init`
3. Verify remote for root isn't set to the Chromium one 

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
