### PR TITLE
Upgrade from Chromium 81.0.4044.122 to Chromium 81.0.4044.129 (uplift to 1.8.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "81.0.4044.122",
+        "tag": "81.0.4044.129",
         "repository": {
           "url": "https://github.com/chromium/chromium.git"
         },


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/9494
Fixes https://github.com/brave/brave-browser/issues/9493
Related https://github.com/brave/brave-core/pull/5404

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
