### PR TITLE
Made UI java tests to run along with brave unit tests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -44,6 +44,11 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
     util.run('ninja', ['-C', config.outputDir, 'brave_installer_unittests'], config.defaultOptions)
   }
 
+  const run_brave_public_test_apk = suite === 'brave_unit_tests' && config.targetOS === 'android'
+  if (run_brave_public_test_apk) {
+    util.run('ninja', ['-C', config.outputDir, 'brave_public_test_apk'], config.defaultOptions)
+  }
+
   if (config.targetOS === 'ios') {
     util.run(path.join(config.outputDir, "iossim"), [
       path.join(config.outputDir, `${suite}.app`),
@@ -59,8 +64,6 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
     if (process.platform === 'win32') {
       testBinary = `${suite}.exe`
       installerTestBinary = 'brave_installer_unittests.exe'
-    } else if (suite === 'brave_public_test_apk' && config.targetOS === 'android') {
-      testBinary = 'bin/run_' + suite
     } else {
       testBinary = suite
       installerTestBinary = 'brave_installer_unittests'
@@ -77,6 +80,10 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
       }
 
       util.run(path.join(config.outputDir, installerTestBinary), braveArgs, config.defaultOptions)
+    }
+
+    if (run_brave_public_test_apk) {
+      util.run(path.join(config.outputDir, 'bin/run_brave_public_test_apk'), braveArgs, config.defaultOptions)
     }
   }
 }


### PR DESCRIPTION
## Submitter Checklist:
Resolves https://github.com/brave/brave-browser/issues/9532

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
