### PR TITLE
Add build_delta_installer option to create_dist

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -193,6 +193,12 @@ Config.prototype.buildArgs = function () {
     args.tag_ap = this.tag_ap
   }
 
+  if (process.platform === 'win32' && this.build_delta_installer) {
+    assert(this.last_chrome_installer, 'Need last_chrome_installer args for building delta installer')
+    args.build_delta_installer = true
+    args.last_chrome_installer = this.last_chrome_installer
+  }
+
   if (this.isDebug() &&
       this.targetOS !== 'ios' &&
       this.targetOS !== 'android') {
@@ -480,6 +486,11 @@ Config.prototype.update = function (options) {
 
   if (options.skip_signing) {
     this.skip_signing = true
+  }
+
+  if (options.build_delta_installer) {
+    this.build_delta_installer = true
+    this.last_chrome_installer = options.last_chrome_installer
   }
 
   if (options.mac_signing_identifier)

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -81,6 +81,8 @@ program
   .option('--build_omaha', 'build omaha stub/standalone installer')
   .option('--tag_ap <ap>', 'ap for stub/standalone installer')
   .option('--skip_signing', 'skip signing dmg/brave_installer.exe')
+  .option('--build_delta_installer', 'build delta mini installer')
+  .option('--last_chrome_installer <last_chrome_installer>', 'folder contains previous version uncompressed chrome.7z pack file. This folder should be in out dir.')
   .option('--android_override_version_name <android_override_version_name>', 'Android version number')
   .option('--brave_safetynet_api_key <brave_safetynet_api_key>')
   .option('--notarize', 'notarize the macOS app with Apple')


### PR DESCRIPTION
To generate delta installer, pass true to build_delta_installer and
pass folder that includes previous versions chrome.7z file to
last_chrome_installer. This folder should be in out dir.
For example, if we want to delta folder for it, create delta folder
to out/Release/delta and copies chrome.7z to it. and pass "delta"
to last_chrome_installer. During the build, couregette.exe will be
copied to that folder.

Issue https://github.com/brave/brave-browser/issues/9565

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
