### PR TITLE
fixed build status init

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,13 +40,13 @@ pipeline {
             }
             steps {
                 script {
-                    if (BUILD_STATUS) {
+                    if (params.BUILD_STATUS) {
                         if (isStartedManually()) {
                             echo "Aborting build as it has been started manually with BUILD_STATUS set"
                             stopCurrentBuild()
                         }
                         else {
-                            currentBuild.result = BUILD_STATUS
+                            currentBuild.result = params.BUILD_STATUS
                         }
                     }
                     else {
@@ -169,13 +169,13 @@ def startBraveBrowserBuild() {
         }
     """)
     params = [
-        string(name: "CHANNEL", value: CHANNEL),
-        string(name: "BUILD_TYPE", value: BUILD_TYPE),
-        booleanParam(name: "WIPE_WORKSPACE", value: WIPE_WORKSPACE),
-        booleanParam(name: "SKIP_INIT", value: SKIP_INIT),
-        booleanParam(name: "DISABLE_SCCACHE", value: DISABLE_SCCACHE),
-        booleanParam(name: "SKIP_SIGNING", value: SKIP_SIGNING),
-        booleanParam(name: "DCHECK_ALWAYS_ON", value: DCHECK_ALWAYS_ON),
+        string(name: "CHANNEL", value: params.CHANNEL),
+        string(name: "BUILD_TYPE", value: params.BUILD_TYPE),
+        booleanParam(name: "WIPE_WORKSPACE", value: params.WIPE_WORKSPACE),
+        booleanParam(name: "SKIP_INIT", value: params.SKIP_INIT),
+        booleanParam(name: "DISABLE_SCCACHE", value: params.DISABLE_SCCACHE),
+        booleanParam(name: "SKIP_SIGNING", value: params.SKIP_SIGNING),
+        booleanParam(name: "DCHECK_ALWAYS_ON", value: params.DCHECK_ALWAYS_ON),
         booleanParam(name: "RUN_NETWORK_AUDIT", value: RUN_NETWORK_AUDIT),
         booleanParam(name: "SKIP_ANDROID", value: SKIP_ANDROID),
         booleanParam(name: "SKIP_IOS", value: SKIP_IOS),


### PR DESCRIPTION
With https://github.com/brave/brave-core/pull/5506

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
