### PR TITLE
Upgrade from Chromium 81 to Chromium 83

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -302,6 +302,7 @@ Config.prototype.buildArgs = function () {
     delete args.brave_referrals_api_key
     delete args.brave_infura_project_id
     delete args.binance_client_id
+    delete args.brave_services_key
   }
 
   if (process.platform === 'win32') {

--- a/lib/config.js
+++ b/lib/config.js
@@ -303,6 +303,7 @@ Config.prototype.buildArgs = function () {
     delete args.brave_infura_project_id
     delete args.binance_client_id
     delete args.brave_services_key
+    delete args.webcompat_report_api_endpoint
   }
 
   if (process.platform === 'win32') {

--- a/lib/config.js
+++ b/lib/config.js
@@ -207,7 +207,6 @@ Config.prototype.buildArgs = function () {
     }
     args.symbol_level = 2
     args.enable_profiling = true
-    args.is_win_fastlink = true
   }
 
   if (this.sccache && process.platform === 'win32') {

--- a/lib/test.js
+++ b/lib/test.js
@@ -3,6 +3,23 @@ const path = require('path')
 const config = require('../lib/config')
 const util = require('../lib/util')
 
+const getTestBinary = (suite) => {
+  return (process.platform === 'win32') ? `${suite}.exe` : suite
+}
+
+const getTestsToRun = (config, suite) => {
+  testsToRun = [suite]
+  if (suite === 'brave_unit_tests') {
+    testsToRun.push('brave_rewards_unit_tests')
+    if (config.targetOS !== 'android') {
+      testsToRun.push('brave_installer_unittests')
+    } else {
+      testsToRun.push('bin/run_brave_public_test_apk')
+    }
+  }
+  return testsToRun
+}
+
 const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
   config.buildConfig = buildConfig
   config.update(options)
@@ -37,17 +54,8 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
   }
 
   // Build the tests
-  util.run('ninja', ['-C', config.outputDir, suite], config.defaultOptions)
-
-  const run_brave_installer_unitests = suite === 'brave_unit_tests' && config.targetOS !== 'android'
-  if (run_brave_installer_unitests) {
-    util.run('ninja', ['-C', config.outputDir, 'brave_installer_unittests'], config.defaultOptions)
-  }
-
-  const run_brave_public_test_apk = suite === 'brave_unit_tests' && config.targetOS === 'android'
-  if (run_brave_public_test_apk) {
-    util.run('ninja', ['-C', config.outputDir, 'brave_public_test_apk'], config.defaultOptions)
-  }
+  const actualSuite = (suite === 'brave_unit_tests') ? 'all_unit_tests' : suite
+  util.run('ninja', ['-C', config.outputDir, actualSuite], config.defaultOptions)
 
   if (config.targetOS === 'ios') {
     util.run(path.join(config.outputDir, "iossim"), [
@@ -55,36 +63,16 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
       path.join(config.outputDir, `${suite}.app/PlugIns/${suite}_module.xctest`)
     ], config.defaultOptions)
   } else {
-    util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name"], config.defaultOptions)
-    util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name_adblock"], config.defaultOptions)
-    util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name_speedreader"], config.defaultOptions)
-
-    let testBinary;
-    let installerTestBinary;
-    if (process.platform === 'win32') {
-      testBinary = `${suite}.exe`
-      installerTestBinary = 'brave_installer_unittests.exe'
-    } else {
-      testBinary = suite
-      installerTestBinary = 'brave_installer_unittests'
-    }
-
+    // Fix the tests
+    util.run('ninja', ['-C', config.outputDir, "fix_all_tests"], config.defaultOptions)
     // Run the tests
-    util.run(path.join(config.outputDir, testBinary), braveArgs, config.defaultOptions)
-
-    if (run_brave_installer_unitests) {
-      // Replace output file arguments
+    getTestsToRun(config, suite).forEach((testSuite) => {
       if (options.output) {
         braveArgs.splice(braveArgs.indexOf('--gtest_output=xml:' + options.output, 1))
-        braveArgs.push('--gtest_output=xml:brave_installer_unittests.xml')
+        braveArgs.push('--gtest_output=xml:${testBinary}.xml')
       }
-
-      util.run(path.join(config.outputDir, installerTestBinary), braveArgs, config.defaultOptions)
-    }
-
-    if (run_brave_public_test_apk) {
-      util.run(path.join(config.outputDir, 'bin/run_brave_public_test_apk'), braveArgs, config.defaultOptions)
-    }
+      util.run(path.join(config.outputDir, getTestBinary(testSuite)), braveArgs, config.defaultOptions)
+    })
   }
 }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -10,6 +10,7 @@ const getTestBinary = (suite) => {
 const getTestsToRun = (config, suite) => {
   testsToRun = [suite]
   if (suite === 'brave_unit_tests') {
+    testsToRun.push('brave_ads_unit_tests')
     testsToRun.push('brave_rewards_unit_tests')
     if (config.targetOS !== 'android') {
       testsToRun.push('brave_installer_unittests')

--- a/lib/test.js
+++ b/lib/test.js
@@ -10,8 +10,6 @@ const getTestBinary = (suite) => {
 const getTestsToRun = (config, suite) => {
   testsToRun = [suite]
   if (suite === 'brave_unit_tests') {
-    testsToRun.push('brave_ads_unit_tests')
-    testsToRun.push('brave_rewards_unit_tests')
     if (config.targetOS !== 'android') {
       testsToRun.push('brave_installer_unittests')
     } else {
@@ -55,8 +53,7 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
   }
 
   // Build the tests
-  const actualSuite = (suite === 'brave_unit_tests') ? 'all_unit_tests' : suite
-  util.run('ninja', ['-C', config.outputDir, actualSuite], config.defaultOptions)
+  util.run('ninja', ['-C', config.outputDir, suite], config.defaultOptions)
 
   if (config.targetOS === 'ios') {
     util.run(path.join(config.outputDir, "iossim"), [

--- a/lib/test.js
+++ b/lib/test.js
@@ -62,7 +62,9 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
     ], config.defaultOptions)
   } else {
     // Fix the tests
-    util.run('ninja', ['-C', config.outputDir, "fix_all_tests"], config.defaultOptions)
+    util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name"], config.defaultOptions)
+    util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name_adblock"], config.defaultOptions)
+    util.run('ninja', ['-C', config.outputDir, "fix_brave_test_install_name_speedreader"], config.defaultOptions)
     // Run the tests
     getTestsToRun(config, suite).forEach((testSuite) => {
       if (options.output) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -69,7 +69,7 @@ const test = (suite, buildConfig = config.defaultBuildConfig, options) => {
     getTestsToRun(config, suite).forEach((testSuite) => {
       if (options.output) {
         braveArgs.splice(braveArgs.indexOf('--gtest_output=xml:' + options.output, 1))
-        braveArgs.push('--gtest_output=xml:${testBinary}.xml')
+        braveArgs.push(`--gtest_output=xml:${testSuite}.xml`)
       }
       util.run(path.join(config.outputDir, getTestBinary(testSuite)), braveArgs, config.defaultOptions)
     })

--- a/lib/util.js
+++ b/lib/util.js
@@ -309,8 +309,6 @@ const util = {
       const androidIconDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium')
       const androidResSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res')
       const androidResDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res')
-      const androidResNightSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res_night')
-      const androidResNightDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_night')
       const androidNtpTilesResSource = path.join(config.projects['brave-core'].dir, 'components', 'ntp_tiles', 'resources')
       const androidNtpTilesResDest = path.join(config.srcDir, 'components', 'ntp_tiles', 'resources')
       const androidResTemplateSource = path.join(config.projects['brave-core'].dir, 'android', 'java', 'res_template')
@@ -322,7 +320,6 @@ const util = {
       const copyAndroidResourceMapping = {
         [androidIconSource]: [androidIconDest],
         [androidResSource]: [androidResDest],
-        [androidResNightSource]: [androidResNightDest],
         [androidNtpTilesResSource]: [androidNtpTilesResDest],
         [androidResTemplateSource]: [androidResTemplateDest],
         [androidContentPublicResSource]: [androidContentPublicResDest]

--- a/lib/util.js
+++ b/lib/util.js
@@ -467,10 +467,22 @@ const util = {
         '--private_key_passphrase=' + passwd])
   },
 
+  copyRedirectCC: () => {
+    // On Windows copy redirect-cc.py to the output dir so we can execute it
+    // from there to shorten the command line in brave/script/redirect-cc.cmd
+    console.log('Copying redirect-cc.py...')
+    const src = path.join(config.projects['brave-core'].dir, 'script', 'redirect-cc.py')
+    const dst = path.join(config.outputDir, 'redirect.py')
+    fs.copyFileSync(src, dst)
+  },
+
   buildTarget: (options = config.defaultOptions) => {
     console.log('building ' + config.buildTarget + '...')
 
-    if (process.platform === 'win32') util.updateOmahaMidlFiles()
+    if (process.platform === 'win32') {
+      util.copyRedirectCC()
+      util.updateOmahaMidlFiles()
+    }
     if (process.platform === 'linux') util.prepareWidevineCdmBuild()
 
     let num_compile_failure = 1

--- a/lib/util.js
+++ b/lib/util.js
@@ -473,6 +473,9 @@ const util = {
     console.log('Copying redirect-cc.py...')
     const src = path.join(config.projects['brave-core'].dir, 'script', 'redirect-cc.py')
     const dst = path.join(config.outputDir, 'redirect.py')
+    if (!fs.existsSync(config.outputDir)) {
+      fs.mkdirSync(config.outputDir);
+    }
     fs.copyFileSync(src, dst)
   },
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "81.0.4044.138",
+        "tag": "83.0.4103.61",
         "repository": {
           "url": "https://github.com/chromium/chromium"
         },


### PR DESCRIPTION
Fixes #9760 
Related PR: brave/brave-core#5102

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
