### PR TITLE
s/brave_referrals_api_key/stats_api_key

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -74,7 +74,7 @@ const Config = function () {
   this.channel = 'development'
   this.git_cache_path = getNPMConfig(['git_cache_path'])
   this.sccache = getNPMConfig(['sccache'])
-  this.braveReferralsApiKey = getNPMConfig(['brave_referrals_api_key']) || ''
+  this.braveStatsApiKey = getNPMConfig(['brave_stats_api_key']) || ''
   this.ignore_compile_failure = false
   this.enable_hangout_services_extension = true
   this.widevineVersion = getNPMConfig(['widevine', 'version'])
@@ -162,7 +162,7 @@ Config.prototype.buildArgs = function () {
     chrome_version_major: chrome_version_parts[0],
     safebrowsing_api_endpoint: this.safeBrowsingApiEndpoint,
     webcompat_report_api_endpoint: this.webcompatReportApiEndpoint,
-    brave_referrals_api_key: this.braveReferralsApiKey,
+    brave_stats_api_key: this.braveStatsApiKey,
     enable_hangout_services_extension: this.enable_hangout_services_extension,
     enable_cdm_host_verification: this.enableCDMHostVerification(),
     skip_signing: !this.shouldSign(),
@@ -300,7 +300,7 @@ Config.prototype.buildArgs = function () {
     delete args.enable_hangout_services_extension
     delete args.brave_google_api_endpoint
     delete args.brave_google_api_key
-    delete args.brave_referrals_api_key
+    delete args.brave_stats_api_key
     delete args.brave_infura_project_id
     delete args.binance_client_id
   }
@@ -464,8 +464,8 @@ Config.prototype.update = function (options) {
     this.webcompatReportApiEndpoint = options.webcompat_report_api_endpoint
   }
 
-  if (options.brave_referrals_api_key) {
-    this.braveReferralsApiKey = options.brave_referrals_api_key
+  if (options.brave_stats_api_key) {
+    this.braveStatsApiKey = options.brave_stats_api_key
   }
 
   if (options.channel) {


### PR DESCRIPTION
We are now using this key for usage pings along with referrals.

https://github.com/brave/brave-core/pull/5632

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
