### PR TITLE
Move all audit_deps logic to brave/script/audit_deps.py

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,8 +18,6 @@
 - [ ] Ran `git rebase -i` to squash commits (if needed).
 - [ ] Tagged reviewers and labelled the pull request as needed.
 - [ ] Requested a security/privacy review as needed.
-- [ ] If adding a new directory with NPM packages, ensure this directory is
-  added to `scripts/audit.js`.
 - [ ] Public documentation has been updated as necessary. For instance:
   - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
   - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -1,38 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-const path = require('path')
-const fs = require('fs')
+const config = require('../lib/config')
 const util = require('../lib/util')
 
-const baseDir = path.resolve(path.join(__dirname, '..'))
-const braveDir = path.join(baseDir, 'src', 'brave')
-const braveVendorDir = path.join(braveDir, 'vendor')
-const syncDir = path.join(braveDir, 'components', 'brave_sync', 'extension', 'brave-sync')
-const auditScript = path.join(braveDir, 'script', 'audit_deps.py')
+let options = config.defaultOptions
+options.continueOnFail = false
+const outputDir = config.outputDir + '_audit'
 
-/**
- * Runs npm audit on a given directory located at pathname
- */
-function npmAudit (pathname) {
-  if (fs.existsSync(path.join(pathname, 'package.json')) &&
-    fs.existsSync(path.join(pathname, 'package-lock.json')) &&
-    fs.existsSync(path.join(pathname, 'node_modules'))) {
-    console.log('Auditing', pathname)
-    let cmdOptions = {
-      cwd: pathname,
-      shell: process.platform === 'win32'
-    }
-    util.run('python', [auditScript], cmdOptions)
-  } else {
-    console.log('Skipping audit of "' + pathname + '" (no package.json or node_modules directory found)')
-  }
-}
+util.updateBranding()
+const args = util.buildArgsToString(config.buildArgs())
+util.run('gn', ['gen', outputDir, '--args="' + args + '"'], options)
 
-npmAudit(baseDir)
-npmAudit(braveDir)
-npmAudit(syncDir)
-fs.readdirSync(braveVendorDir).forEach((dir) => {
-  npmAudit(path.join(braveVendorDir, dir))
-})
+let ninjaOpts = [
+  '-C', outputDir, 'brave:audit_deps',
+  ...config.extraNinjaOpts,
+]
+util.run('ninja', ninjaOpts, options)


### PR DESCRIPTION
Dependency of https://github.com/brave/brave-core/pull/5755.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

    npm run audit_deps

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
