### PR TITLE
Patches: treat certain error paths as warnings

### DIFF
--- a/lib/applyPatches.js
+++ b/lib/applyPatches.js
@@ -5,7 +5,7 @@ const applyPatches = (buildConfig = config.defaultBuildConfig, options) => {
   async function RunCommand () {
     config.buildConfig = buildConfig
     config.update(options)
-    await util.applyPatches()
+    await util.applyPatches(true)
   }
 
   RunCommand().catch((err) => {

--- a/lib/sync/logging.js
+++ b/lib/sync/logging.js
@@ -52,23 +52,32 @@ function command (dir, cmd, args) {
   console.log(`${cmdArrowStyle('>')} ${cmdCmdStyle(cmd)} ${args.join(' ')}`)
 }
 
-function allPatchStatus(allPatchStatus, patchGroupName) {
+function allPatchStatus(allPatchStatus, patchGroupName, ignoreErrorPaths) {
   if (!allPatchStatus.length) {
     console.log(chalk.bold.italic(`There were no ${patchGroupName} code patch updates to apply.`))
   } else {
     const successfulPatches = []
     const failedPatches = []
+    const warningPatches = []
     for (const patchStatus of allPatchStatus) {
       if (!patchStatus.error) {
         successfulPatches.push(patchStatus)
       } else {
-        failedPatches.push(patchStatus)
+        if (ignoreErrorPaths.includes(patchStatus.path)) {
+          warningPatches.push(patchStatus)
+        } else {
+          failedPatches.push(patchStatus)
+        }
       }
     }
     console.log(chalk.bold(`There were ${allPatchStatus.length} ${patchGroupName} code patch updates to apply.`))
     if (successfulPatches.length) {
       console.log(chalk.green(`${successfulPatches.length} successful patches:`))
       successfulPatches.forEach(logPatchStatus)
+    }
+    if (warningPatches.length) {
+      console.log(chalk.yellow(`${warningPatches.length} non-fatal patch issue:`))
+      warningPatches.forEach(p => logPatchStatus(p, true))
     }
     if (failedPatches.length) {
       console.log(chalk.red(`${failedPatches.length} failed patches:`))
@@ -77,24 +86,25 @@ function allPatchStatus(allPatchStatus, patchGroupName) {
   }
 }
 
-function logPatchStatus ({ reason, path, patchPath, error, warning }) {
+function logPatchStatus ({ reason, path, patchPath, error, warning }, isWarning = false) {
   const GitPatcher = require('../gitPatcher')
   const success = !error
-  const statusColor = success ? chalk.green : chalk.red
-  console.log(statusColor.bold.underline(path || patchPath))
+  const statusStyle = success ? chalk.green : isWarning ? chalk.yellow : chalk.red
+  console.log(statusStyle.bold.underline(path || patchPath))
   console.log(`  - Patch applied because: ${GitPatcher.patchApplyReasonMessages[reason]}`)
   if (error) {
-    console.log(chalk.red(`  - Error - ${error.message}`))
+    console.log(statusStyle(`  - Error - ${error.message}`))
   }
   if (warning) {
-    console.warn(chalk.yellow(`  - Warning - ${warning}`))
+    console.warn(statusStyle(`  - Warning - ${warning}`))
   }
   if (error)  {
     if (error.stdout) {
       console.log(chalk.blue(error.stdout))
     }
     if (error.stderr) {
-      console.error(chalk.red(error.stderr))
+      console.error('    - For reference, the output from applying the patch was:')
+      console.error(statusStyle(error.stderr))
     }
   }
   console.log(divider)

--- a/lib/util.js
+++ b/lib/util.js
@@ -29,7 +29,12 @@ const mergeWithDefault = (options) => {
   return Object.assign({}, config.defaultOptions, options)
 }
 
-async function applyPatches() {
+
+const patchIgnoreErrorPaths = [
+  'chrome/VERSION'
+]
+
+async function applyPatches(canIgnoreSomeErrors = false) {
   const GitPatcher = require('./gitPatcher')
   Log.progress('Applying patches...')
   // Always detect if we need to apply patches, since user may have modified
@@ -54,9 +59,18 @@ async function applyPatches() {
   v8PatchStatus.forEach(s => s.path = path.join('v8', s.path))
   devtoolsFrontendSrcStatus.forEach(s => s.path = path.join('devtoolsFrontendSrc', s.path))
   const allPatchStatus = chromiumPatchStatus.concat(v8PatchStatus).concat(devtoolsFrontendSrcStatus)
-  Log.allPatchStatus(allPatchStatus, 'Chromium')
-
-  const hasPatchError = allPatchStatus.some(p => p.error)
+  const warningErrorPaths = canIgnoreSomeErrors ? patchIgnoreErrorPaths : []
+  Log.allPatchStatus(allPatchStatus, 'Chromium', warningErrorPaths)
+  const fnPatchStatusHasError = p => {
+    if (!p.error) {
+      return false
+    }
+    if (!canIgnoreSomeErrors) {
+      return true
+    }
+    return !patchIgnoreErrorPaths.includes(p.path)
+  }
+  const hasPatchError = allPatchStatus.some(fnPatchStatusHasError)
   Log.progress('Done applying patches.')
   // Exit on error in any patch
   if (hasPatchError) {
@@ -675,8 +689,8 @@ const util = {
     runGClient(args, options)
   },
 
-  applyPatches: () => {
-    return applyPatches()
+  applyPatches: (canIgnoreSomeErrors = false) => {
+    return applyPatches(canIgnoreSomeErrors)
   },
 
   buildArgsToString: (buildArgs) => {

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -86,7 +86,8 @@ async function RunCommand () {
   }
   Log.progress('...gclient sync done')
 
-  await util.applyPatches()
+  const canIgnoreSomePatchErrors = !program.init && !program.force
+  await util.applyPatches(canIgnoreSomePatchErrors)
 
   util.gclientRunhooks()
 }


### PR DESCRIPTION
Only 'chrome/VERSION' for now

Doesn't quit the `sync` command if these paths cannot have their patch applied.

![image](https://user-images.githubusercontent.com/741836/85610844-38fa1e00-b60c-11ea-936e-e3404db65599.png)
