### PR TITLE
Sync gets post-sync git ref logging

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -144,6 +144,10 @@ const util = {
       })
   },
 
+  getGitReadableLocalRef: (repoDir) => {
+    return util.runGit(repoDir, ['log', '-n', '1', '--pretty=format:%h%d'], true)
+  },
+
   buildGClientConfig: () => {
     function replacer(key, value) {
       return value;
@@ -601,7 +605,8 @@ const util = {
     const targetSHA = util.runGit(config.srcDir, ['rev-parse', chromiumRef], true)
     const needsUpdate = ((targetSHA !== headSHA) || (!headSHA && !targetSHA))
     if (needsUpdate) {
-      console.log(`Chromium repo ${chalk.blue.bold('needs update')}. Target is ${chalk.italic(chromiumRef)} at commit ${targetSHA || '[missing]'} but current commit is ${chalk.inverse(headSHA || '[missing]')}.`)
+      const currentRef = util.getGitReadableLocalRef(config.srcDir)
+      console.log(`Chromium repo ${chalk.blue.bold('needs update')}. Target is ${chalk.italic(chromiumRef)} at commit ${targetSHA || '[missing]'} but current commit is ${chalk.italic(currentRef || '[unknown]')} at commit ${chalk.inverse(headSHA || '[missing]')}.`)
     } else {
       console.log(chalk.green.bold(`Chromium repo does not need update as it is already ${chalk.italic(chromiumRef)} at commit ${targetSHA || '[missing]'}.`))
     }
@@ -617,6 +622,7 @@ const util = {
     const resetArgs = ['--with_tags', '--with_branch_heads', '--upstream']
 
     let args = [...initialArgs]
+    let didUpdateChromium = false
 
     if (forceReset || braveCoreRef) {
       if (!braveCoreRef) {
@@ -636,6 +642,7 @@ const util = {
     if (forceReset || util.shouldUpdateChromium()) {
       args = [...args, ...chromiumArgs]
       reset = true
+      didUpdateChromium = true
     }
 
     if (forceReset) {
@@ -652,7 +659,10 @@ const util = {
 
     runGClient(args, options)
 
-    Log.progress(`Done syncing gclient`)
+    return {
+      didUpdateChromium,
+      braveCoreRef
+    }
   },
 
   gclientRunhooks: (options = {}) => {


### PR DESCRIPTION
Adds the refs that chromium (src/) and brave (src/brave) are at _after_ gclient sync, in order to validate that build issues occurred on the expected checkouts.

Helps diagnose some infrequent CI issues with build errors that are the result of unexpected checkouts occurring during sync. Even if the checkouts are expected, this logging makes it explicit to the developer that there _wasn't_ an issue with sync.

### Logging with these changes:

![image](https://user-images.githubusercontent.com/741836/85614458-c25f1f80-b60f-11ea-959e-ca448a4b458b.png)
----
![image](https://user-images.githubusercontent.com/741836/85614491-ca1ec400-b60f-11ea-9ccd-fec3cb80613f.png)
