### PR TITLE
Fix 9365: Add gn check to npm scripts

### DIFF
--- a/lib/gnCheck.js
+++ b/lib/gnCheck.js
@@ -1,0 +1,10 @@
+const config = require('../lib/config')
+const util = require('../lib/util')
+
+const gnCheck = (buildConfig = config.defaultBuildConfig, options) => {
+  config.buildConfig = buildConfig
+  config.update(options)
+  util.run('gn', ['check', config.outputDir, '//brave/*'], config.defaultOptions)
+}
+
+module.exports = gnCheck

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "sync": "node ./scripts/sync.js",
     "gclient": "node ./scripts/gclient.js",
     "build": "node ./scripts/commands.js build",
+    "gn_check": "node ./scripts/commands.js gn_check",
     "versions": "node ./scripts/commands.js versions",
     "upload": "node ./scripts/commands.js upload",
     "update_patches": "node ./scripts/commands.js update_patches",

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -19,6 +19,7 @@ const l10nDeleteTranslations = require('../lib/l10nDeleteTranslations')
 const createDist = require('../lib/createDist')
 const upload = require('../lib/upload')
 const test = require('../lib/test')
+const gnCheck = require('../lib/gnCheck')
 
 const collect = (value, accumulator) => {
   accumulator.push(value)
@@ -37,6 +38,14 @@ program
 program
   .command('versions')
   .action(versions)
+
+program
+  .command('gn_check')
+  .option('--target_os <target_os>', 'target OS')
+  .option('--target_arch <target_arch>', 'target architecture')
+  .option('--target_apk_base <target_apk_base>', 'target Android OS apk (classic, modern, mono)', 'classic')
+  .arguments('[build_config]')
+  .action(gnCheck)
 
 program
   .command('apply_patches')


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/9365

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:
CI should pass

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
