### PR TITLE
Fix 9365: Add gn check to npm scripts (Uplift 1.11.x)

### DIFF
--- a/lib/gnCheck.js
+++ b/lib/gnCheck.js
@@ -1,0 +1,10 @@
+const config = require('../lib/config')
+const util = require('../lib/util')
+
+const gnCheck = (buildConfig = config.defaultBuildConfig, options) => {
+  config.buildConfig = buildConfig
+  config.update(options)
+  util.run('gn', ['check', config.outputDir, '//brave/*'], config.defaultOptions)
+}
+
+module.exports = gnCheck

--- a/lib/gnCheck.js
+++ b/lib/gnCheck.js
@@ -2,6 +2,10 @@ const config = require('../lib/config')
 const util = require('../lib/util')
 
 const gnCheck = (buildConfig = config.defaultBuildConfig, options) => {
+  // Return true for gn_check for version 1.11.x and 1.12.x
+  if (config.braveVersion.startsWith('1.11') || config.braveVersion.startsWith('1.12')) {
+    return;
+  }
   config.buildConfig = buildConfig
   config.update(options)
   util.run('gn', ['check', config.outputDir, '//brave/*'], config.defaultOptions)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "sync": "node ./scripts/sync.js",
     "gclient": "node ./scripts/gclient.js",
     "build": "node ./scripts/commands.js build",
+    "gn_check": "node ./scripts/commands.js gn_check",
     "versions": "node ./scripts/commands.js versions",
     "upload": "node ./scripts/commands.js upload",
     "update_patches": "node ./scripts/commands.js update_patches",

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -19,6 +19,7 @@ const l10nDeleteTranslations = require('../lib/l10nDeleteTranslations')
 const createDist = require('../lib/createDist')
 const upload = require('../lib/upload')
 const test = require('../lib/test')
+const gnCheck = require('../lib/gnCheck')
 
 const collect = (value, accumulator) => {
   accumulator.push(value)
@@ -37,6 +38,14 @@ program
 program
   .command('versions')
   .action(versions)
+
+program
+  .command('gn_check')
+  .option('--target_os <target_os>', 'target OS')
+  .option('--target_arch <target_arch>', 'target architecture')
+  .option('--target_apk_base <target_apk_base>', 'target Android OS apk (classic, modern, mono)', 'classic')
+  .arguments('[build_config]')
+  .action(gnCheck)
 
 program
   .command('apply_patches')


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/10599
Resolves : https://github.com/brave/brave-browser/issues/9365

Approved, please ensure that before merging: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.