### PR TITLE
7957: Initialize branding_path_component = "brave" in config.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -144,6 +144,7 @@ Config.prototype.buildArgs = function () {
     is_component_build: this.isComponentBuild(),
     proprietary_codecs: true,
     ffmpeg_branding: "Chrome",
+    branding_path_component: "brave",
     enable_nacl: false,
     enable_widevine: true,
     target_cpu: this.targetArch,
@@ -309,6 +310,7 @@ Config.prototype.buildArgs = function () {
     delete args.safe_browsing_mode
     delete args.proprietary_codecs
     delete args.ffmpeg_branding
+    delete args.branding_path_component
     delete args.enable_nacl
     delete args.branding_path_component
     delete args.enable_widevine


### PR DESCRIPTION
This removes the need of having to handle this as via a chromium
patch + a brave specific variable in build/features.gni.

Fix brave/brave-browser#7957


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] macOS
  - [ ] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows
- [x] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Requested a security/privacy review as needed.
- [ ] If adding a new directory with NPM packages, ensure this directory is
  added to `scripts/audit.js`.
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection

## Test Plan:

N/A

## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions.

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.