### PR TITLE
Fix init util script to use config from manifest

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,13 @@
 const Log = require('./logging')
 const { spawnSync } = require('child_process')
 
+const getFallbackConfig = (path) => {
+  let ownManifest = require('../package.json').config
+  for (const key of path)
+        ownManifest = ownManifest ? ownManifest[key] : undefined
+  return ownManifest
+}
+
 const getNPMConfig = (path) => {
   const key = path.join('_').replace('-', '_')
   const npm_prefix = 'npm_config_'
@@ -8,7 +15,8 @@ const getNPMConfig = (path) => {
   const package_prefix = 'npm_package_'
   return process.env[npm_prefix + key] ||
     process.env[package_config_prefix + key] ||
-    process.env[package_prefix + key]
+    process.env[package_prefix + key] ||
+    getFallbackConfig(path)
 }
 
 const getProjectVersion = (projectName) => {


### PR DESCRIPTION
When sub-projects are not specified in process env variables,
init script will get default values from package manifest entry
called "config".

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves #16254.

## Submitter Checklist:

- [x] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Crate a new checkout following instructions in README:
```
git clone git@github.com:brave/brave-browser.git
cd brave-browser/
npm i
```
and observe that `npm run init` runs successfuly:
```
$ npm run init

> brave@1.27.42 init
> node ./scripts/init.js

Performing initial checkout of brave-core
Cloning brave-core [master] into ~/brave-browser/src/brave...
-------------------------------------------------------------------------------
~/brave-browser/src/brave
> git clone https://github.com/brave/brave-core.git .
-------------------------------------------------------------------------------
~/brave-browser/src/brave
> git checkout master
-------------------------------------------------------------------------------
~/brave-browser/src/brave
> npm.cmd install
```

Previously `npm run init` would error out:
```
$ npm run init

> brave@1.27.42 init
> node ./scripts/init.js

Performing initial checkout of brave-core
Cloning brave-core [undefined] into ~/brave-browser/src/brave...
-------------------------------------------------------------------------------
~/brave-browser/src/brave
> git clone  .

fatal: repository 'undefined' does not exist
```
