### PR TITLE
Upgrade from Chromium 91.0.4472.106 to Chromium 91.0.4472.114 (uplift to 1.26.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "91.0.4472.106",
+        "tag": "91.0.4472.114",
         "repository": {
           "url": "https://github.com/chromium/chromium"
         }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/16490

Fixes brave/brave-browser#16489
Related PR: https://github.com/brave/brave-core/pull/9183
