### PR TITLE
Revert "Upgrade from Chromium 91 to Chromium 92 (1.27.x)."

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "92.0.4515.93",
+        "tag": "91.0.4472.124",
         "repository": {
           "url": "https://github.com/chromium/chromium"
         }


### PR DESCRIPTION
Reverts brave/brave-browser#16818

The PR was merged too early (the counterpart PR brave/brave-core#9361 wasn't ready to merge yet).