### PR TITLE
Upgrade from Chromium 95.0.4638.40 to Chromium 95.0.4638.49 (1.31.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "projects": {
       "chrome": {
         "dir": "src",
-        "tag": "95.0.4638.40",
+        "tag": "95.0.4638.49",
         "repository": {
           "url": "https://github.com/chromium/chromium"
         }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/pull/18752