### PR TITLE
Upgrade from Chromium 96.0.4664.35 to Chromium 96.0.4664.45 (uplift to 1.32.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "projects": {
       "brave-core": {
         "dir": "src/brave",
-        "branch": "1.32.x",
+        "branch": "96.0.4664.45_master_140-1.32.x",
         "repository": {
           "url": "https://github.com/brave/brave-core.git"
         }

--- a/package.json
+++ b/package.json
@@ -233,13 +233,6 @@
   },
   "config": {
     "projects": {
-      "chrome": {
-        "dir": "src",
-        "tag": "96.0.4664.35",
-        "repository": {
-          "url": "https://github.com/chromium/chromium"
-        }
-      },
       "brave-core": {
         "dir": "src/brave",
         "branch": "1.32.x",


### PR DESCRIPTION
Fixes brave/brave-browser#16419
Uplift of #16558

Related PR: https://github.com/brave/brave-core/pull/11038

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 

Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.