### PR TITLE
Add rebase when PRs move from draft to ready for review

### DIFF
--- a/.github/workflows/pr_ready_for_review.yml
+++ b/.github/workflows/pr_ready_for_review.yml
@@ -1,0 +1,33 @@
+name: Ready for Review Rebase
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+  add_label:
+    if: contains(github.event.pull_request.labels.*.name, 'CI/run-draft') != true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: add rebase label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: rebase
+
+      - name: git checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+
+      - name: automatic rebase
+        uses: cirrus-actions/rebase@1.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: remove label
+        if: always()
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: rebase


### PR DESCRIPTION
Resolves https://github.com/brave/devops/issues/6595
Creates an action that will perform a rebase when a PR is moved from draft to ready for review. 
This is to trigger a fresh CI run (as we don't run CI against draft PRs) and ensure the PR is up to date before being reviewed and merged.  
If the label `CI/run-draft` is present, it will not rebase as CI will have been run on pushes to the branch. 
The rebase label is added as part of the action to give visibility to PR owners and reviewers this has taken place.

## Submitter Checklist:

- [x] Confirms that no security/privacy review [is needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or that one has been [requested](https://github.com/brave/security/issues/new/choose)
- [x] There is a [ticket](https://github.com/brave/devops/issues) for this
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] All relevant documentation has been updated - at least [here](https://github.com/brave/devops/wiki)
- [x] Performed a self-review before removing WIP label
- [x] Asked for review from the right people

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/handbook/blob/master/development/security.md#when-is-a-security-review-needed), or a link to one is included in the PR description
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Code follows the style guide
- [ ] Plans below are specified in PR before merging
- [ ] Branch being deployed from is protected in GitHub (PR approval required and no force push) - production only

## Deploy Plan:
- [ ] N/A

## Rollback Plan:
- [ ] N/A

## Test Plan:
- [ ] N/A

This change has been deployed to:
- [ ] development
- [ ] staging
- [ ] production (tag @channel in #prod-changes if this may have wider impact)
- [x] N/A
