### PR TITLE
Merge pull request #19994 from brave/issues/19993

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,7 +1,11 @@
+const fs = require('fs')
 const Log = require('./logging')
 const { spawnSync } = require('child_process')
 
-const getNPMConfig = (path) => {
+// This is the valid way of retrieving configuration values for NPM <= 6, with
+// npm_package_config_* still working up to NPM 7, but no longer for NPM >= 8.
+// See https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md
+const getNPMConfigFromEnv = (path) => {
   const key = path.join('_')
   // Npm <= 6 did not preserve dashes in package.json keys
   const keyNoDashes = key.replace('-', '_')
@@ -14,6 +18,29 @@ const getNPMConfig = (path) => {
     process.env[package_prefix + keyNoDashes] ||
     process.env[package_prefix + key]
 }
+
+// From NPM >= 8, we need to inspect the package.json file, which should
+// be available via the 'npm_package_json' environment variable.
+const getNPMConfigFromPackageJson = (path) => {
+  let packages = { config: {} }
+  if (fs.existsSync(process.env['npm_package_json'])) {
+    packages = require(process.env['npm_package_json'])
+  }
+
+  let obj = packages.config
+  for (var i = 0, len = path.length; i < len; i++) {
+    if (!obj) {
+      return obj
+    }
+    obj = obj[path[i]]
+  }
+  return obj
+}
+
+const getNPMConfig = (path) => {
+  return getNPMConfigFromEnv(path) || getNPMConfigFromPackageJson(path)
+}
+
 
 const getProjectVersion = (projectName) => {
   return getNPMConfig(['projects', projectName, 'tag']) || getNPMConfig(['projects', projectName, 'branch'])


### PR DESCRIPTION
From NPM >=6 and as explained in RFC 21[1], npm is removing the
npm_config_* and npm_package_* environment variables from the
context of lifecycle scripts and so, while some of them such
as the npm_package_config_* ones will still work on NPM 7, we
need to adapt to this change or it won't be able to setup the
repository from NPM 8 on.

This change does a small change to make sure that we work on
every possible situation, relying on those environment variables
if still using NPM <= 7, or simply reading the package.json file
as a dictionary when using NPM >= 8.

[1] https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md

Resolves https://github.com/brave/brave-browser/issues/19993

Uplift from https://github.com/brave/brave-browser/pull/19994

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A
  - [ ] https://github.com/brave/brave-browser/wiki/Brave-Wallet

## Test Plan:
