### PR TITLE
Add iOS issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ios.md
+++ b/.github/ISSUE_TEMPLATE/ios.md
@@ -1,0 +1,46 @@
+---
+name: iOS Issue
+about: Template for logging issues on iOS
+title: ""
+labels: OS/iOS
+assignees: ''
+
+---
+
+<!-- Have you searched for similar issues? Before submitting this issue, please check the open issues and add a note before logging a new issue. 
+
+PLEASE USE THE TEMPLATE BELOW TO PROVIDE INFORMATION ABOUT THE ISSUE. 
+INSUFFICIENT INFO WILL GET THE ISSUE CLOSED. IT WILL ONLY BE REOPENED AFTER SUFFICIENT INFO IS PROVIDED-->
+
+## Description: 
+
+
+## Steps to Reproduce 
+  1.
+  2.
+  3.
+
+## Actual result: <!-- Add screenshots if needed -->
+
+
+## Expected result:
+
+
+## Reproduces how often: [Easily reproduced, Intermittent Issue]
+
+
+## Brave Version: <!-- Provide full details Eg: 1.62.0 (102) -->
+
+- Can you reproduce this issue with the most recent build from TestFlight? 
+- Can you reproduce this issue with the previous version of the current build from TestFlight? 
+- Can you reproduce this issue with the current build from AppStore? 
+
+### Device details: <!-- Model type and iOS version Eg: iPhone 6s+ (iOS 10.3.3)-->
+
+
+### Website problems only:
+- Does the issue resolve itself when disabling Brave Shields?
+- Is the issue reproducible on the latest version of Mobile Safari? 
+
+### Additional Information
+<!-- Any additional information, related issues, extra QA steps, configuration or data that might be necessary to reproduce the issue -->


### PR DESCRIPTION
This simply adds an iOS issue template since we're going to start logging more iOS issues here in the future 