### PR TITLE
Automatically label issues based on regular expression matches in title and description

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+# This is a mapping of labels to title/description regex patterns used by
+# https://github.com/github/issue-labeler to automatically add labels to issues
+# when opened/edited.
+#
+# If multiple patterns are provided in the list for a label, they all have to
+# match. A label can only occur once.
+#
+# To label when any one of multiple patterns matches, concatenate the patterns
+# using a "|" delimeter, to form a single pattern.
+#
+# "^" appears to match only the beginning of the issue title.
+#
+# Automatic label removal is currently disabled, because it also removes
+# manually added labels that didn't have matches.
+
+crash:
+  - '^Crash Report|Crash ID: crash/'
+
+OS/Linux:
+  - 'OS[|:\s]+Linux|Operating System:\s+Linux'
+
+OS/Windows:
+  - 'OS[|:\s]+Windows|Operating System:\s+Windows NT'
+
+OS/macOS:
+  - 'OS[|:\s]+Mac OS|Operating System:\s+Mac OS X'
+
+OS/Android:
+  - 'OS[|:\s]+Android|Operating System:\s+Android'
+
+OS/iOS:
+  - 'OS[|:\s]+iOS|Device/OS:\s+iPhone|Operating System:\s+iOS'

--- a/.github/workflows/assign-issue-labels.yml
+++ b/.github/workflows/assign-issue-labels.yml
@@ -1,0 +1,18 @@
+name: Assign issue labels
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+      with:
+        enable-versioned-regex: 0
+        include-title: 1
+        #sync-labels: 1 # This removes also manually added labels on edit


### PR DESCRIPTION
This is an implementation based on https://github.com/github/issue-labeler. The action has some quirks, but it's maintained by GitHub and security approved. If we don't like the behavior, we could potentially switch to something else, or even implement our own from scratch.

I added some patterns to start, but the expectation is that others would add more.

Please assign as reviewers and/or tag anyone who should see this and comment.

## Submitter Checklist:

- [ ] I confirm that no security/privacy review [is needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or that I have [requested](https://github.com/brave/security/issues/new/choose) one
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally: `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests`, `npm run lint`, `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A
  - [ ] https://github.com/brave/brave-browser/wiki/Brave-Wallet

## Test Plan:
