### PR TITLE
Seperated and Added to the Linux and Andriod Install Pages

### DIFF
--- a/Android.md
+++ b/Android.md
@@ -1,0 +1,57 @@
+
+# Android Development Environment
+
+## Making Debug Build for Android
+
+To ensure the output format is APK, add `--target_android_output_format=apk` to the build command:
+
+```bash
+npm run build -- Debug --target_os=android --target_arch=arm --target_android_output_format=apk
+```
+
+To change the target SDK level, add `--target_android_base`:
+
+```bash
+npm run build -- Debug --target_os=android --target_arch=arm --target_android_output_format=apk --target_android_base=mono
+```
+
+## Installing a Build on Android
+
+For devices or an emulator:
+
+```bash
+./src/build/android/adb_install_apk.py ./src/out/android_Debug_x86/apks/Bravex86.apk
+```
+
+Or:
+
+```bash
+adb install ./src/out/android_Debug_x86/apks/Bravex86.apk
+```
+
+If you have an AAB file:
+
+```bash
+bundletool build-apks --connected-device --bundle=out/android_Debug_x86/apks/Bravex86.aab --output=out/android_Debug_x86/apks/Bravex86.apks
+bundletool install-apks --apks=out/android_Debug_x86/apks/Bravex86.apks
+```
+
+## Getting Crash Dumps for Android
+
+```bash
+adb logcat -d | third_party/android_platform/development/scripts/stack --output-directory out/android_Component_arm
+```
+
+## Other Debugging Instructions for Android
+
+Refer to the [Chromium debugging instructions](https://chromium.googlesource.com/chromium/src/+/main/docs/android_debugging_instructions.md).
+
+## Setting Up an Android Emulator
+
+To set up an Android emulator, follow these steps:
+
+1. Install Android Studio from the [official website](https://developer.android.com/studio).
+2. Open Android Studio and navigate to the AVD Manager.
+3. Create a new virtual device and select the desired phone model and system image.
+4. Configure the emulator settings and finish the setup.
+5. Start the emulator from the AVD Manager.

--- a/Linux.md
+++ b/Linux.md
@@ -1,0 +1,63 @@
+
+# Linux Development Environment
+
+## System Requirements
+
+Ensure your system satisfies the [system requirements](https://chromium.googlesource.com/chromium/src/+/main/docs/linux_build_instructions.md#System-requirements).
+
+## Install Additional Build Dependencies
+
+You will need Git, Python 3 and Node.js active LTS (v20+). You may need to make python3 the default if Python 2.7 is default for your OS. Also, if you don't have anything named python on your machine and only have `python3`, you will need something like `python-is-python3`
+
+Alternatively, you can use Yarn. Follow the [Yarn install docs](https://yarnpkg.com/getting-started/install) to install Yarn and a compatible version of Node.js. After installing Yarn, run `yarn import` to create a `yarn.lock` file from `package-lock.json`.
+
+## Additonal installs for different Linux distributions: 
+
+### For Ubuntu Users
+
+```bash
+apt-get install build-essential python-setuptools python3-distutils
+```
+
+### For Fedora Users
+
+```bash
+dnf install @development-tools python3-devel
+```
+
+### For Arch Linux Users
+
+```bash
+pacman -S base-devel python
+```
+
+### For Red Hat Users
+```bash
+yum groupinstall 'Development Tools' && yum install python3-devel
+```
+
+### For openSUSE Users
+
+```bash
+zypper install -t pattern devel_basis
+zypper install python3-devel
+```
+
+### General Instructions
+
+After cloning and initializing the repo, run the following script to finish installing build dependencies:
+
+```bash
+# cd to brave-browser repo root
+./src/build/install-build-deps.sh # for Linux
+```
+
+For unsupported distributions:
+
+```bash
+./src/build/install-build-deps.sh --unsupported
+```
+
+## Troubleshooting
+
+Check out the upstream [Checking out and building Chromium on Linux](https://chromium.googlesource.com/chromium/src/+/main/docs/linux_build_instructions.md#Checking-out-and-building-Chromium-on-Linux) docs before filing an issue.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves #38572 

Submitter Checklist:

- [ ]  I confirm that no security/privacy review is needed, or that I have requested one
- [ ] There is a ticket for my issue
- [ ] Used Github auto-closing keywords in the PR description above
- [ ] Wrote a good PR/commit description
- [ ] Added appropriate labels (QA/Yes or QA/No; release-notes/include or release-notes/exclude; OS/...) to the associated issue
- [ ] Checked the PR locally: npm run test -- brave_browser_tests, npm run test -- brave_unit_tests, npm run lint, npm run gn_check, npm run tslint
- [ ] Ran git rebase master (if needed)

I separated the Linux and Android install pages as to provide more clarity for developers targeting these operating systems. I also added some additional information for more Linux distributions and a short guide on setting up the Android emulator. This is addressing the open issue: #38572. 

Currently I have added the two files  in the home directory as markdown files, as I don't have permission to edit the Wiki directly.  
