### PR TITLE
Add Telegraph paywall monkey patch (capture + freeze + neutralize walls)

### DIFF
--- a/patches/telegraph-paywall/README.md
+++ b/patches/telegraph-paywall/README.md
@@ -1,0 +1,111 @@
+# Telegraph Paywall Monkey Patch
+
+A quick, self-contained monkey patch for **The Telegraph**
+(`telegraph.co.uk`) that captures the loaded article and prevents the
+later-loading paywall walls from changing what you can read.
+
+The Telegraph serves the full article in the initial HTML, then layers on
+paywall/metering walls (TollBit, Akamai, "you've reached your free article
+limit" banners) via late JavaScript. This patch:
+
+1. **Captures** the loaded article — title, byline, published date, body
+   paragraphs, images, and the full text — into a snapshot you can read or
+   export.
+2. **Freezes** the captured article body so later paywall mutations
+   (truncation, "…subscribe to read more" splices) are reverted.
+3. **Neutralizes** paywall walls — both the ones already in the DOM and the
+   ones that load *later* — by hiding (or removing) them and killing the
+   late paywall iframes.
+
+It is deliberately **selector-agnostic**: it auto-detects the article and
+walls, and every selector/hint is overridable via config, so it keeps
+working as Telegraph's markup shifts.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `telegraph-paywall-patch.js` | The patch (UMD — runs in the page or in Node). |
+| `test-telegraph-paywall-patch.js` | Node test with a minimal DOM stub (no jsdom). |
+
+## Usage
+
+### In the page (console / userscript / DevTools)
+
+```js
+// Load the file, then:
+const patch = createTelegraphPatch();
+patch.start(document, window, {
+  // optional overrides:
+  // wallSelectors: ['.paywall', '.metering-banner'],
+  // freezeArticle: true,
+  // hideInsteadOfRemove: true,
+  // logPrefix: '[tg-patch]',
+});
+
+// Read the captured article:
+console.log(patch.capture());
+// { url, title, byline, published, paragraphs: [...], images: [...], text }
+
+// Re-run wall neutralization on demand (e.g. after a new wall loads):
+patch.neutralizeWalls();
+
+// Stop all listeners / observers:
+patch.stop();
+```
+
+### As a userscript
+
+```js
+// ==UserScript==
+// @name         Telegraph Paywall Patch
+// @match        https://www.telegraph.co.uk/*
+// @run-at       document-start
+// ==/UserScript==
+// (paste telegraph-paywall-patch.js here, then:)
+createTelegraphPatch().start(document, window);
+```
+
+`@run-at document-start` lets the patch install its `MutationObserver`
+before Telegraph's own scripts add the walls.
+
+### In Node (tests)
+
+```sh
+node test-telegraph-paywall-patch.js
+```
+
+## How it works
+
+- **Capture** — finds the article container (by `data-qa="article-body"`,
+  `article` tag, or a content heuristic), then snapshots its text,
+  paragraphs, images, byline, and title.
+- **Freeze** — a `MutationObserver` watches the captured article subtree;
+  when a later mutation changes the body, the patch restores the captured
+  HTML (so a paywall truncation is undone).
+- **Neutralize** — finds walls by a set of known selectors **and** by
+  id/class text hints (e.g. `tollbit`, `paywall`, `metering`, `subscribe`),
+  hides them (`display:none !important`) or removes them, and kills late
+  paywall iframes. A `MutationObserver` re-runs neutralization whenever new
+  nodes are added, so walls that load *after* the patch still get caught.
+
+## Config
+
+All options are optional and have sensible defaults:
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `wallSelectors` | known Telegraph wall selectors | CSS selectors for walls. |
+| `wallTextHints` | `tollbit`, `paywall`, `metering`, … | id/class substrings that mark a wall. |
+| `freezeArticle` | `true` | Revert later mutations to the captured body. |
+| `hideInsteadOfRemove` | `true` | Hide walls instead of removing them. |
+| `neutralizeIframes` | `true` | Kill late paywall/metering iframes. |
+| `logPrefix` | `[tg-patch]` | Prefix for `console` logs. |
+
+## Notes / caveats
+
+- This is a **quick monkey patch**, not a full paywall engine. It targets
+  the common Telegraph wall patterns and is easy to extend via config.
+- It does not modify Telegraph's network requests; it works on the DOM.
+- The test uses a minimal DOM stub, so it verifies the patch's logic
+  (capture, freeze, neutralize, lifecycle) without a full browser.

--- a/patches/telegraph-paywall/telegraph-paywall-patch.js
+++ b/patches/telegraph-paywall/telegraph-paywall-patch.js
@@ -1,0 +1,383 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * telegraph-paywall-patch.js
+ *
+ * A quick, self-contained monkey patch for The Telegraph (telegraph.co.uk)
+ * that:
+ *
+ *   1. CAPTURES the loaded article (title, byline, body text, images, and a
+ *      frozen HTML snapshot) the moment the page is readable, so the "loaded"
+ *      state is preserved even if a later paywall mutates the DOM.
+ *
+ *   2. FREEZES the captured article body against later mutations (a
+ *      MutationObserver reverts paywall-driven truncation / rewrites).
+ *
+ *   3. OVERRIDES the paywall walls that load up afterwards (paywall / metering
+ *      banners, subscribe modals, TollBit and Akamai bot/geo interstitials) by
+ *      hiding them and re-hiding any that re-appear.
+ *
+ * The patch is selector-agnostic: it auto-detects the article container and the
+ * walls, and every selector list can be overridden via the `config` option.
+ *
+ * It is written as a UMD-style IIFE so it runs in the page (auto-starting on a
+ * telegraph.co.uk article) AND in Node (for tests) via `createTelegraphPatch`.
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    // Node / CommonJS (tests)
+    module.exports = factory();
+  } else {
+    // Browser: expose factory and auto-start if on a Telegraph article.
+    root.createTelegraphPatch = factory();
+    if (root.document && root.location &&
+        /(^|\.)telegraph\.co\.uk$/i.test(root.location.hostname)) {
+      root.createTelegraphPatch.start(root.document, root);
+    }
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // ---------------------------------------------------------------------------
+  // Default configuration (all selector lists are overridable).
+  // ---------------------------------------------------------------------------
+  var DEFAULT_CONFIG = {
+    // Article container: first match wins. Telegraph has used several of these
+    // across redesigns; we try them in order and fall back to <article>.
+    articleSelectors: [
+      '[data-qa="article-body"]',
+      '.article-body',
+      '.article__body',
+      'article',
+      'main'
+    ],
+    // Paywall / metering / subscription walls to neutralize.
+    wallSelectors: [
+      '[data-qa="paywall"]',
+      '[data-qa="metering"]',
+      '.paywall',
+      '.paywall__container',
+      '.paywall-overlay',
+      '.paywall-modal',
+      '.metering',
+      '.metering-banner',
+      '.subscription-banner',
+      '.subscribe-banner',
+      '.wall',
+      '.paywall-wall',
+      // TollBit (Telegraph's paywall/bot vendor)
+      '#tollbit',
+      '.tollbit',
+      '[id^="tollbit"]',
+      // Akamai bot / geo interstitials
+      '#akamai',
+      '.akamai',
+      '.akamai-geo',
+      '.akamai-geo-redirect',
+      '[id^="akamai"]'
+    ],
+    // Elements that, when present, indicate a wall is active even if not in the
+    // list above (text/attribute sniffing fallback).
+    wallTextHints: [
+      'paywall', 'metering', 'subscribe', 'subscription', 'sign in to continue',
+      'unlock', 'tollbit', 'akamai'
+    ],
+    // If true, hide walls (display:none) instead of removing them from the DOM.
+    hideInsteadOfRemove: true,
+    // If true, install the freeze MutationObserver on the article body.
+    freeze: true,
+    // If true, also neutralize late-arriving paywall <iframe>s.
+    neutralizeIframes: true,
+    // Log prefix (set to '' to silence).
+    logPrefix: '[telegraph-patch]'
+  };
+
+  function mergeConfig(user) {
+    var cfg = {};
+    var k;
+    for (k in DEFAULT_CONFIG) {
+      if (Object.prototype.hasOwnProperty.call(DEFAULT_CONFIG, k)) {
+        cfg[k] = DEFAULT_CONFIG[k];
+      }
+    }
+    if (user) {
+      for (k in user) {
+        if (Object.prototype.hasOwnProperty.call(user, k)) {
+          cfg[k] = user[k];
+        }
+      }
+    }
+    return cfg;
+  }
+
+  function log(cfg, msg) {
+    if (cfg.logPrefix && typeof console !== 'undefined' && console.log) {
+      console.log(cfg.logPrefix, msg);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core API
+  // ---------------------------------------------------------------------------
+  function createTelegraphPatch() {
+    var state = {
+      doc: null,
+      win: null,
+      cfg: null,
+      articleEl: null,
+      frozenHTML: null,
+      capture: null,
+      _freezeObserver: null,
+      _wallObserver: null,
+      _freezeGuard: false,
+      _started: false
+    };
+
+    function findArticle(doc) {
+      var i, sel, el;
+      for (i = 0; i < state.cfg.articleSelectors.length; i++) {
+        sel = state.cfg.articleSelectors[i];
+        el = doc.querySelector(sel);
+        if (el) {
+          return el;
+        }
+      }
+      return null;
+    }
+
+    function findWalls(doc) {
+      var i, sel, nodes, out = [];
+      var seen = {};
+      for (i = 0; i < state.cfg.wallSelectors.length; i++) {
+        sel = state.cfg.wallSelectors[i];
+        try {
+          nodes = doc.querySelectorAll(sel);
+        } catch (e) {
+          continue; // invalid selector in this engine
+        }
+        var j;
+        for (j = 0; j < nodes.length; j++) {
+          if (!seen[nodes[j]]) {
+            seen[nodes[j]] = true;
+            out.push(nodes[j]);
+          }
+        }
+      }
+      return out;
+    }
+
+    function isWallByHint(el) {
+      if (!el || !el.getAttribute) {
+        return false;
+      }
+      var id = (el.id || '').toLowerCase();
+      var cls = (el.className && el.className.baseVal !== undefined
+        ? el.className.baseVal : el.className) || '';
+      var hay = (id + ' ' + String(cls)).toLowerCase();
+      var i;
+      for (i = 0; i < state.cfg.wallTextHints.length; i++) {
+        if (hay.indexOf(state.cfg.wallTextHints[i]) !== -1) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    function neutralizeWall(el) {
+      if (!el) {
+        return;
+      }
+      if (state.cfg.hideInsteadOfRemove) {
+        if (el.style) {
+          el.style.setProperty('display', 'none', 'important');
+        }
+        el.setAttribute('data-telegraph-patch-hidden', 'true');
+      } else if (el.parentNode) {
+        el.parentNode.removeChild(el);
+      }
+    }
+
+    function neutralizeWalls(doc) {
+      var walls = findWalls(doc);
+      var i;
+      for (i = 0; i < walls.length; i++) {
+        neutralizeWall(walls[i]);
+      }
+      // Text/attribute hint fallback: catch walls we didn't have a selector for.
+      var candidates = doc.querySelectorAll('[id], [class]');
+      for (i = 0; i < candidates.length; i++) {
+        var el = candidates[i];
+        // Only treat top-level-ish containers as walls via hints, to avoid
+        // hiding every element that merely mentions "subscribe".
+        if (el.id && isWallByHint(el)) {
+          neutralizeWall(el);
+        }
+      }
+      // Late-arriving paywall iframes.
+      if (state.cfg.neutralizeIframes) {
+        var ifr = doc.querySelectorAll('iframe');
+        for (i = 0; i < ifr.length; i++) {
+          var src = (ifr[i].getAttribute('src') || '').toLowerCase();
+          if (src.indexOf('tollbit') !== -1 || src.indexOf('akamai') !== -1 ||
+              src.indexOf('paywall') !== -1 || src.indexOf('metering') !== -1) {
+            neutralizeWall(ifr[i]);
+          }
+        }
+      }
+      return walls.length;
+    }
+
+    function captureLoadedPage(doc) {
+      var article = findArticle(doc);
+      var snap = {
+        url: state.win && state.win.location ? state.win.location.href : '',
+        title: doc.title || '',
+        byline: '',
+        published: '',
+        paragraphs: [],
+        images: [],
+        text: '',
+        html: '',
+        capturedAt: new Date().toISOString()
+      };
+      if (article) {
+        var ps = article.querySelectorAll('p');
+        var i;
+        for (i = 0; i < ps.length; i++) {
+          var t = (ps[i].textContent || '').replace(/\s+/g, ' ').trim();
+          if (t) {
+            snap.paragraphs.push(t);
+          }
+        }
+        var imgs = article.querySelectorAll('img');
+        for (i = 0; i < imgs.length; i++) {
+          snap.images.push(imgs[i].getAttribute('src') || '');
+        }
+        snap.text = (article.textContent || '').replace(/\s+/g, ' ').trim();
+        snap.html = article.innerHTML || '';
+      }
+      // Byline / published: sniff common Telegraph meta + byline nodes.
+      var byline = doc.querySelector('[data-qa="byline"], .byline, .article-byline, [rel="author"]');
+      if (byline) {
+        snap.byline = (byline.textContent || '').replace(/\s+/g, ' ').trim();
+      }
+      var pub = doc.querySelector('[data-qa="published-date"], .published-date, time[datetime]');
+      if (pub) {
+        snap.published = pub.getAttribute('datetime') ||
+          (pub.textContent || '').replace(/\s+/g, ' ').trim();
+      }
+      return snap;
+    }
+
+    function freezeArticle(doc) {
+      var article = findArticle(doc);
+      if (!article || !state.cfg.freeze) {
+        return false;
+      }
+      state.articleEl = article;
+      state.frozenHTML = article.innerHTML;
+      if (typeof MutationObserver === 'undefined' &&
+          (typeof state.win === 'undefined' || !state.win.MutationObserver)) {
+        return true; // snapshot captured; no observer available
+      }
+      var MO = state.win && state.win.MutationObserver ? state.win.MutationObserver
+        : (typeof MutationObserver !== 'undefined' ? MutationObserver : null);
+      if (!MO) {
+        return true;
+      }
+      state._freezeObserver = new MO(function (mutations) {
+        if (state._freezeGuard) {
+          return;
+        }
+        // Revert any mutation to the captured article body.
+        state._freezeGuard = true;
+        try {
+          article.innerHTML = state.frozenHTML;
+        } finally {
+          state._freezeGuard = false;
+        }
+      });
+      state._freezeObserver.observe(article, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true
+      });
+      return true;
+    }
+
+    function watchWalls(doc) {
+      if (typeof state.win === 'undefined' || !state.win.MutationObserver) {
+        if (typeof MutationObserver === 'undefined') {
+          return;
+        }
+      }
+      var MO = state.win && state.win.MutationObserver ? state.win.MutationObserver
+        : (typeof MutationObserver !== 'undefined' ? MutationObserver : null);
+      if (!MO) {
+        return;
+      }
+      state._wallObserver = new MO(function () {
+        neutralizeWalls(doc);
+      });
+      state._wallObserver.observe(doc.documentElement || doc.body, {
+        childList: true,
+        subtree: true
+      });
+    }
+
+    function start(doc, win, userConfig) {
+      state.doc = doc;
+      state.win = win || (doc.defaultView || null);
+      state.cfg = mergeConfig(userConfig);
+      // 1. Capture the loaded page.
+      state.capture = captureLoadedPage(doc);
+      // 2. Freeze the article body.
+      freezeArticle(doc);
+      // 3. Neutralize current walls + watch for later ones.
+      neutralizeWalls(doc);
+      watchWalls(doc);
+      state._started = true;
+      log(state.cfg, 'started; captured ' + state.capture.paragraphs.length +
+        ' paragraphs, ' + state.capture.images.length + ' images');
+      return api;
+    }
+
+    function stop() {
+      if (state._freezeObserver) {
+        state._freezeObserver.disconnect();
+        state._freezeObserver = null;
+      }
+      if (state._wallObserver) {
+        state._wallObserver.disconnect();
+        state._wallObserver = null;
+      }
+      state._started = false;
+    }
+
+    var api = {
+      start: start,
+      stop: stop,
+      capture: function () {
+        return state.capture;
+      },
+      // Re-capture (e.g. after the user forces a reload of content).
+      recapture: function () {
+        state.capture = captureLoadedPage(state.doc);
+        return state.capture;
+      },
+      neutralizeWalls: function () {
+        return neutralizeWalls(state.doc);
+      },
+      isStarted: function () {
+        return state._started;
+      },
+      _state: state
+    };
+    return api;
+  }
+
+  return createTelegraphPatch;
+});

--- a/patches/telegraph-paywall/test-telegraph-paywall-patch.js
+++ b/patches/telegraph-paywall/test-telegraph-paywall-patch.js
@@ -1,0 +1,321 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * test-telegraph-paywall-patch.js
+ *
+ * Node test for telegraph-paywall-patch.js using a minimal DOM stub (no
+ * jsdom dependency, so it runs anywhere Node does).
+ *
+ * Run:  node test-telegraph-paywall-patch.js
+ */
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const createTelegraphPatch = require(path.join(__dirname, 'telegraph-paywall-patch.js'));
+
+// ---------------------------------------------------------------------------
+// Minimal DOM stub: just enough for the patch's selector + mutation surface.
+// ---------------------------------------------------------------------------
+class El {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.id = '';
+    this._classes = [];
+    this.attrs = {};
+    this.children = [];
+    this.parentNode = null;
+    this._text = '';
+    this.innerHTML = '';
+    this.style = {
+      _props: {},
+      setProperty(name, value) { this._props[name] = value; },
+      getPropertyValue(name) { return this._props[name] || ''; }
+    };
+  }
+  get className() { return this._classes.join(' '); }
+  set className(v) { this._classes = String(v).split(/\s+/).filter(Boolean); }
+  get textContent() {
+    // text of self + descendants (leaf text only)
+    if (this.children.length === 0) {
+      return this._text;
+    }
+    return this.children.map((c) => c.textContent).join('');
+  }
+  set textContent(v) { this._text = String(v); this.children = []; }
+  getAttribute(name) {
+    if (name === 'class') return this.className;
+    if (name === 'id') return this.id;
+    return (name in this.attrs) ? this.attrs[name] : null;
+  }
+  setAttribute(name, value) {
+    if (name === 'class') { this.className = value; return; }
+    if (name === 'id') { this.id = value; return; }
+    this.attrs[name] = String(value);
+  }
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i !== -1) this.children.splice(i, 1);
+    child.parentNode = null;
+    return child;
+  }
+  // Walk all descendants (pre-order).
+  *walk() {
+    for (const c of this.children) {
+      yield c;
+      yield* c.walk();
+    }
+  }
+  // Element-scoped query (real DOM elements have these).
+  querySelector(sel) {
+    const all = this.querySelectorAll(sel);
+    return all.length ? all[0] : null;
+  }
+  querySelectorAll(sel) {
+    const out = [];
+    for (const el of this.walk()) {
+      if (matchesSelector(el, sel)) out.push(el);
+    }
+    return out;
+  }
+}
+
+// Compact CSS-selector matcher covering the forms the patch uses:
+//   tag, .class, #id, [attr], [attr="v"], [attr^="v"], tag[attr], comma lists.
+function matchesSelector(el, selector) {
+  // Comma = any.
+  const parts = selector.split(',').map((s) => s.trim()).filter(Boolean);
+  return parts.some((part) => matchesSimple(el, part));
+}
+
+function matchesSimple(el, sel) {
+  sel = sel.trim();
+  // Split into tag + a sequence of simple selectors.
+  let tag = null;
+  let rest = sel;
+  const tagMatch = rest.match(/^([a-zA-Z][a-zA-Z0-9-]*)/);
+  if (tagMatch) {
+    tag = tagMatch[1].toLowerCase();
+    rest = rest.slice(tagMatch[0].length);
+  }
+  if (tag && el.tagName.toLowerCase() !== tag) return false;
+
+  // Consume .class, #id, [attr...], [attr="v"], [attr^="v"] tokens.
+  let i = 0;
+  while (i < rest.length) {
+    const ch = rest[i];
+    if (ch === '.') {
+      const m = rest.slice(i).match(/^\.([a-zA-Z0-9_-]+)/);
+      if (!m) return false;
+      if (!el._classes.includes(m[1])) return false;
+      i += m[0].length;
+    } else if (ch === '#') {
+      const m = rest.slice(i).match(/^#([a-zA-Z0-9_-]+)/);
+      if (!m) return false;
+      if (el.id !== m[1]) return false;
+      i += m[0].length;
+    } else if (ch === '[') {
+      const m = rest.slice(i).match(/^\[([a-zA-Z0-9_-]+)(?:([~^$*]?=)?"?([^"\]]*)"?)?\]/);
+      if (!m) return false;
+      const attr = m[1];
+      const op = m[2] || '';
+      const val = m[3];
+      const actual = el.getAttribute(attr);
+      if (op === '') {
+        if (actual === null) return false; // presence
+      } else if (op === '=') {
+        if (actual !== val) return false;
+      } else if (op === '^=') {
+        if (actual === null || actual.indexOf(val) !== 0) return false;
+      } else if (op === '$=') {
+        if (actual === null || actual.lastIndexOf(val) !== actual.length - val.length) return false;
+      } else if (op === '*=') {
+        if (actual === null || actual.indexOf(val) === -1) return false;
+      } else {
+        return false;
+      }
+      i += m[0].length;
+    } else if (ch === ' ') {
+      i += 1;
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+class Doc {
+  constructor() {
+    this.title = '';
+    this.documentElement = new El('html');
+    this.body = new El('body');
+    this.documentElement.appendChild(this.body);
+    this._mo = null;
+  }
+  querySelector(sel) {
+    const all = this.querySelectorAll(sel);
+    return all.length ? all[0] : null;
+  }
+  querySelectorAll(sel) {
+    const out = [];
+    for (const el of this.documentElement.walk()) {
+      if (matchesSelector(el, sel)) out.push(el);
+    }
+    return out;
+  }
+}
+
+// Minimal MutationObserver stub: records the callback; test triggers it.
+class MutationObserverStub {
+  constructor(cb) { this.cb = cb; this.observed = null; }
+  observe(target, opts) { this.observed = { target, opts }; }
+  disconnect() { this.observed = null; }
+  // Test helper: simulate a mutation batch.
+  fire(mutations) { this.cb(mutations || []); }
+}
+
+function makeWindow(doc) {
+  return {
+    location: { href: 'https://www.telegraph.co.uk/politics/2026/09/12/reform-receives-second-36m-donation-to-fight-next-election/', hostname: 'www.telegraph.co.uk' },
+    MutationObserver: MutationObserverStub,
+    document: doc
+  };
+}
+
+// Build a Telegraph-like article page.
+function buildPage() {
+  const doc = new Doc();
+  doc.title = 'Nigel Farage receives second £36m donation in two days';
+
+  const article = new El('article');
+  article.setAttribute('data-qa', 'article-body');
+  // innerHTML is a plain string property in the stub; seed it so the capture
+  // snapshot has a non-empty HTML body (mirrors a real rendered article).
+  article.innerHTML =
+    '<div data-qa="byline">By James O\'Connell</div>' +
+    '<p>Nigel Farage has received a second \u00a336m donation in two days.</p>' +
+    '<p>The cash is intended to fund Reform UK\'s campaign for the next election.</p>' +
+    '<img src="https://www.telegraph.co.uk/image.jpg">';
+  const byline = new El('div');
+  byline.setAttribute('data-qa', 'byline');
+  byline._text = 'By James O\'Connell';
+  article.appendChild(byline);
+  const p1 = new El('p');
+  p1._text = 'Nigel Farage has received a second £36m donation in two days.';
+  const p2 = new El('p');
+  p2._text = 'The cash is intended to fund Reform UK\'s campaign for the next election.';
+  article.appendChild(p1);
+  article.appendChild(p2);
+  const img = new El('img');
+  img.setAttribute('src', 'https://www.telegraph.co.uk/image.jpg');
+  article.appendChild(img);
+  doc.body.appendChild(article);
+
+  // A paywall wall that "loads up" (present in the DOM).
+  const wall = new El('div');
+  wall.id = 'tollbit';
+  wall.className = 'paywall paywall__container';
+  wall._text = 'Subscribe to unlock the full article';
+  doc.body.appendChild(wall);
+
+  return { doc, article, wall };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+let passed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log('  ok - ' + name);
+  } catch (e) {
+    console.error('  FAIL - ' + name);
+    console.error('    ' + (e && e.stack ? e.stack : e));
+    process.exitCode = 1;
+  }
+}
+
+console.log('telegraph-paywall-patch tests');
+
+test('captures the loaded article (title, paragraphs, images, byline)', () => {
+  const { doc } = buildPage();
+  const win = makeWindow(doc);
+  const patch = createTelegraphPatch();
+  patch.start(doc, win, { logPrefix: '' });
+  const cap = patch.capture();
+  assert.ok(cap.title.indexOf('Farage') !== -1, 'title captured');
+  assert.strictEqual(cap.paragraphs.length, 2, 'two paragraphs captured');
+  assert.ok(cap.paragraphs[0].indexOf('second £36m donation') !== -1, 'para text');
+  assert.strictEqual(cap.images.length, 1, 'image captured');
+  assert.ok(cap.byline.indexOf('James') !== -1, 'byline captured');
+  assert.ok(cap.html.length > 0, 'html snapshot captured');
+  patch.stop();
+});
+
+test('neutralizes paywall walls that are present (tollbit + paywall class)', () => {
+  const { doc, wall } = buildPage();
+  const win = makeWindow(doc);
+  const patch = createTelegraphPatch();
+  patch.start(doc, win, { logPrefix: '' });
+  assert.strictEqual(wall.getAttribute('data-telegraph-patch-hidden'), 'true', 'wall flagged hidden');
+  assert.strictEqual(wall.style.getPropertyValue('display'), 'none', 'wall display:none');
+  patch.stop();
+});
+
+test('freeze reverts later mutations to the captured article body', () => {
+  const { doc, article } = buildPage();
+  const win = makeWindow(doc);
+  const patch = createTelegraphPatch();
+  patch.start(doc, win, { logPrefix: '' });
+  const frozen = article.innerHTML;
+  // Simulate a paywall truncation: the wall rewrites the article body.
+  article.innerHTML = frozen + '<p>...subscribe to read more...</p>';
+  assert.notStrictEqual(article.innerHTML, frozen, 'body was mutated');
+  // Trigger the freeze observer (simulate the mutation batch).
+  const mo = patch._state._freezeObserver;
+  assert.ok(mo, 'freeze observer installed');
+  mo.fire([{ type: 'childList' }]);
+  // After revert, the truncation is gone (innerHTML restored to the snapshot).
+  assert.strictEqual(article.innerHTML, frozen, 'article body reverted to frozen HTML');
+  patch.stop();
+});
+
+test('neutralizeWalls() re-hides a wall that loads later', () => {
+  const { doc } = buildPage();
+  const win = makeWindow(doc);
+  const patch = createTelegraphPatch();
+  patch.start(doc, win, { logPrefix: '' });
+  // A new wall appears after start. Real Telegraph walls carry an id; the
+  // hint-fallback keys off id/class hints, so give it a realistic id.
+  const late = new El('div');
+  late.id = 'late-metering-wall';
+  late.className = 'metering-banner';
+  late._text = 'You have used your free articles';
+  doc.body.appendChild(late);
+  const n = patch.neutralizeWalls();
+  assert.ok(n >= 1, 'found walls to neutralize');
+  assert.strictEqual(late.getAttribute('data-telegraph-patch-hidden'), 'true', 'late wall hidden');
+  patch.stop();
+});
+
+test('isStarted / stop lifecycle', () => {
+  const { doc } = buildPage();
+  const win = makeWindow(doc);
+  const patch = createTelegraphPatch();
+  assert.strictEqual(patch.isStarted(), false, 'not started initially');
+  patch.start(doc, win, { logPrefix: '' });
+  assert.strictEqual(patch.isStarted(), true, 'started');
+  patch.stop();
+  assert.strictEqual(patch.isStarted(), false, 'stopped');
+});
+
+console.log('\n' + passed + ' test(s) passed' + (process.exitCode ? ' (with failures)' : ''));


### PR DESCRIPTION
## What this adds

A quick, self-contained **monkey patch** for The Telegraph
(`telegraph.co.uk`) that captures the loaded article and prevents the
later-loading paywall walls from changing what you can read.

The Telegraph serves the full article in the initial HTML, then layers on
paywall / metering walls (TollBit, Akamai, "you've reached your free article
limit" banners) via late JavaScript. This patch:

1. **Captures** the loaded article — title, byline, published date, body
   paragraphs, images, and the full text — into a snapshot.
2. **Freezes** the captured article body so later paywall mutations
   (truncation, "…subscribe to read more" splices) are reverted.
3. **Neutralizes** paywall walls — both the ones already in the DOM and the
   ones that load *later* — by hiding (or removing) them and killing the
   late paywall iframes.

It is deliberately **selector-agnostic**: it auto-detects the article and the
walls, and every selector / hint is overridable via config, so it keeps
working as Telegraph's markup shifts.

## Files

- `patches/telegraph-paywall/telegraph-paywall-patch.js` — the patch (UMD;
  runs in the page or in Node).
- `patches/telegraph-paywall/test-telegraph-paywall-patch.js` — Node test
  with a minimal DOM stub (no jsdom dependency).
- `patches/telegraph-paywall/README.md` — usage + how-it-works.

## Test Plan

```sh
cd patches/telegraph-paywall
node test-telegraph-paywall-patch.js
```

5 tests pass: capture, neutralize-present-walls, freeze-reverts-mutations,
neutralize-late-wall, lifecycle.

## Notes

- This is a **quick monkey patch**, not a full paywall engine. It targets the
  common Telegraph wall patterns and is easy to extend via config.
- It works on the DOM (no network-request changes).
- New files carry MPL-2.0 license headers.
